### PR TITLE
Change GPIO4 to BL0937 CF (type 134).

### DIFF
--- a/_templates/bn-link_bnc-60.markdown
+++ b/_templates/bn-link_bnc-60.markdown
@@ -6,8 +6,8 @@ type: Plug
 standard: us
 link: https://www.amazon.com/gp/product/B07HPG58FP/
 image: https://user-images.githubusercontent.com/5904370/54481150-5d742180-4831-11e9-8dea-6e1cbf6ef1bd.png
-template: '{"NAME":"BNC-60/U133TJ","GPIO":[0,56,0,17,133,132,0,0,131,57,21,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"BNC-60/U133TJ","GPIO":[0,56,0,17,134,132,0,0,131,57,21,0,0],"FLAG":0,"BASE":18}' 
 link_alt: 
 ---
 
-Same configuration as European ANCCY plug.
+Same configuration as European ANCCY plug except GPIO4.


### PR DESCRIPTION
Based on a hardware tear down, the power monitoring chip is really a BL0937, not a HLW8012. The only thing this changes is GPIO4. Making this change will cause the default calibration to be much closer and better centered in the calibration range.