### PR TITLE
Create Jinvoo Smart WiFi Valve SM-AW713

### DIFF
--- a/_templates/Jinvoo Smart WiFi Valve SM-AW713
+++ b/_templates/Jinvoo Smart WiFi Valve SM-AW713
@@ -1,0 +1,12 @@
+date: 2019-06-02
+title:  JinvooSmart SM-AW713
+category: misc
+type: Valve
+standard: global
+link: https://www.amazon.co.uk/Jinvoo-Control-SM-AW713-Application-Program/dp/B07H3RT8X8/ref=sr_1_1?keywords=B07H3RT8X8&qid=1559480379&s=gateway&sr=8-1
+image: https://images-na.ssl-images-amazon.com/images/I/61mxgUPxbSL._SL1500_.jpg
+template: {"NAME":"Jinvoo Valve","GPIO":[0,0,0,0,0,52,0,0,21,17,0,0,0],"FLAG":0,"BASE":18}
+link_alt: 
+---
+
+derived from JinvooSmart SM-PW713 template (using that template, would keep reseting the SM-AW713 back to basic WiFi hotspot after a few switch ON/OFF)


### PR DESCRIPTION
I stumbled upon JinvooSmart SM-PW713 template, but using that on the JinvooSmart SM-AW713, would keep reseting the device back to basic WiFi hotspot after a few switch ON/OFF.
I tried a few other available templates and with the "ESP switch" I could control this valve (using the 4th button), so I modified the JinvooSmart SM-PW713 to make use of the GPIOs from "ESP switch" one.
So, this template keeps SM-AW713 stable and fully functional (including the toggle button on the valve).

Thanks
Adrian