### PR TITLE
Use ButtonN instead of SwitchN for DS102-3

### DIFF
--- a/_templates/DS-102_3
+++ b/_templates/DS-102_3
@@ -6,8 +6,8 @@ type: Switch
 standard: eu
 link: https://www.aliexpress.com/item/Tuya-Smart-life-app-Control-WiFi-Light-86-EU-Button-Switch-Support-Alexa-Google-Home/32996551323.html
 image: https://user-images.githubusercontent.com/5904370/56752390-6fc67100-6788-11e9-926b-8afd519cef61.png
-template: '{"NAME":"DS-102 3 Gang","GPIO":[158,58,0,10,22,11,0,0,9,21,57,23,56],"FLAG":0,"BASE":18}' 
-link_alt: 
+template: '{"NAME":"DS-102 3 Gang","GPIO":[158,58,0,18,22,19,0,0,17,21,57,23,56],"FLAG":0,"BASE":18}'
+link_alt:
 ---
 This device template requires Tasmota 6.5.0.12 which has support for LEDs linked to Relays.
 


### PR DESCRIPTION
The template incorrectly used switches for the buttons, which meant the light would only stay on while the button is held down.