### PR TITLE
Use blue LED as status LED for NX-SM200

### DIFF
--- a/_templates/oxaoxe_NX-SM200
+++ b/_templates/oxaoxe_NX-SM200
@@ -6,8 +6,8 @@ type: Plug
 standard: eu
 link: https://www.amazon.es/gp/product/B07MQ4734T/
 image: https://i.imgur.com/sYi1W8Q.png
-template: '{"NAME":"NX-SM200","GPIO":[17,0,0,0,133,132,0,0,131,52,21,0,0],"FLAG":0,"BASE":65}' 
-link_alt: 
+template: '{"NAME":"NX-SM200","GPIO":[17,0,0,0,133,132,0,0,131,158,21,0,0],"FLAG":0,"BASE":18}'
+link_alt:
 ---
 
 Can be flashed with tuya-convert.


### PR DESCRIPTION
The red LED already turns on and off with the relay (both connected to
GPIO 14). So we can use the blue LED (GPIO 13) for status.