### PR TITLE
Update ZSP-001

### DIFF
--- a/_templates/ZSP-001
+++ b/_templates/ZSP-001
@@ -6,7 +6,7 @@ type: Plug
 standard: ch
 link: https://www.aliexpress.com/item/33006588699.html
 image: https://ae01.alicdn.com/kf/HTB1BPLCSIbpK1RjSZFyq6x_qFXa6/Smart-Swiss-Plug-16A-Switzerland-Wifi-Socket-Voice-Control-Works-With-Google-Home-Alexa-IFTTT-Tuya.jpg
-template: '{"NAME":"ZSP-001","GPIO":[17,255,255,255,133,132,255,255,130,56,21,255,57],"FLAG":1,"BASE":18}' 
+template: '{"NAME":"ZSP-001","GPIO":[17,255,255,255,133,132,255,255,130,57,21,255,56],"FLAG":1,"BASE":18}' 
 link_alt: 
 ---
 


### PR DESCRIPTION
Switch Red and Blue led. Now the red led is used when there is a WiFi/MQTT connection issue and the blue led for the relay.