### PR TITLE
Update template for SWB1

### DIFF
--- a/_templates/swb1.markdown
+++ b/_templates/swb1.markdown
@@ -6,7 +6,7 @@ type: Power Strip
 standard: us
 link: https://www.amazon.com/Aneken-Protector-Individually-Controlled-Compatible/dp/B07FDX6XZ6
 image: https://user-images.githubusercontent.com/5904370/54648203-9fa59900-4aa5-11e9-9701-f3586d9375da.png
-template: '{"NAME":"Viflykoo 3xStr","GPIO":[0,0,53,0,0,23,0,0,21,56,17,24,22],"FLAG":1,"BASE":18}'
+template: '{"NAME":"SWB1","GPIO":[52,0,0,0,0,24,0,0,21,17,22,23,0],"FLAG":0,"BASE":18}'
 link_alt: https://www.aliexpress.com/item/2000W-WiFi-Socket-Portable-SWB1-Smart-Power-Strip-Intelligent-4-Ports-Plug-Wifi-Wireless-Remote-Power/32883983405.html
 ---
 ### Product


### PR DESCRIPTION
The template for SWB1 does not match what is on the Tasmota GitHub. Updated to match, and can confirm the new template works on my SWB1s flashed with tuya-convert.

https://github.com/arendst/Sonoff-Tasmota/wiki/SWB1-Smart-Power-Strip