### PR TITLE
Button is inverted, GPIO16 isn't available

### DIFF
--- a/_templates/awp04l.markdown
+++ b/_templates/awp04l.markdown
@@ -5,12 +5,12 @@ type: Plug
 standard: us
 link: https://www.amazon.com/Smart-Outlet-Compatible-Alexa-Google/dp/B07LGSBFNJ
 image: https://i.postimg.cc/rsnJGpTS/small-201810291602080595.jpg
-template: '{"NAME":"AWP04L","GPIO":[57,255,255,131,255,134,0,0,21,17,132,56,255],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"AWP04L","GPIO":[158,255,255,131,255,134,0,0,21,122,132,56,0],"FLAG":0,"BASE":18}' 
 link_alt: 
 ---
 
 
-These devices come with different brands,  but all have AWP04L serial number on the back sticker.
+These devices come with different brands, but all have AWP04L serial number on the back sticker.
 
 
 


### PR DESCRIPTION
Button is inverted, GPIO16 isn't available on the module. Also use red LED as Link indicator.