### PR TITLE
Update AWP04L Template

### DIFF
--- a/_templates/awp04l.markdown
+++ b/_templates/awp04l.markdown
@@ -5,7 +5,7 @@ type: Plug
 standard: us
 link: https://www.amazon.com/Smart-Outlet-Compatible-Alexa-Google/dp/B07LGSBFNJ
 image: https://i.postimg.cc/rsnJGpTS/small-201810291602080595.jpg
-template: '{"NAME":"AWP04L","GPIO":[158,255,255,131,255,134,0,0,21,122,132,56,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"AWP04L","GPIO":[57,255,255,131,255,134,0,0,21,17,132,56,255],"FLAG":0,"BASE":18}' 
 link_alt: 
 ---
 


### PR DESCRIPTION
It looks like the template was changed to {"NAME":"AWP04L","GPIO":[158,255,255,131,255,134,0,0,21,122,132,56,0],"FLAG":0,"BASE":18} which causes my unit to lock up and clear it's settings. I pulled this template from one of my working units (installed last weekend) and it is working now.

I've had several others run into the same issue and this change has worked for them. We are chatting on the DrZzzzs page on Facebook. 