### PR TITLE
Update and rename mirabella_genio_downlight_RGBCCT to mirabella_genio…

### DIFF
--- a/_templates/mirabella_genio_downlight_CCT
+++ b/_templates/mirabella_genio_downlight_CCT
@@ -1,6 +1,6 @@
 ---
 date: 2019-10-20
-title: Mirabella Genio Downlight RGB+CCT
+title: Mirabella Genio Downlight CCT
 category: light
 type: Light
 standard: anzac


### PR DESCRIPTION
…_downlight_CCT

This template is definitely for the CCT variant of these downlights, and the template matches CCT as well as product links and images (the alt link has it as the second on the page).  

As per documentation here: https://github.com/arendst/Sonoff-Tasmota/wiki/Lights an RGB+CCT would require 5 PWM channels to be configured, this template has two.