### PR TITLE
Update neocoolcam_16a

### DIFF
--- a/_templates/neocoolcam_16a.markdown
+++ b/_templates/neocoolcam_16a.markdown
@@ -1,5 +1,5 @@
 ---
-date: 2019-04-22
+date: 2019-10-27
 title: NEO Coolcam 16A
 category: plug
 type: Plug
@@ -10,5 +10,10 @@ template: '{"NAME":"Neo Coolcam 16","GPIO":[17,0,0,0,133,132,0,0,131,56,21,0,0],
 link_alt: https://www.szneo.com/en/products/show.php?id=215
 ---
 
-Converted via tuya-convert, shipped with tuya firmware 1.0.4 (both, chinese, czech)
+The first template is intended for legacy devices that use a HLW8012 circuit for power monitoring. Newer devices (Q2/2019) include a Belling BL0937 chip and therefore, GPIO04 has to be changed to 134:
+```
+{"NAME":"Neo Coolcam 16","GPIO":[17,0,0,0,134,132,0,0,131,56,21,0,0],"FLAG":0,"BASE":49}
+```
+If used with the wrong setting, i.e. 133 instead of 134, the voltage readout will show values like 780V instead of 230V.
 
+All revisions of this plug can be flashed using tuya-convert.


### PR DESCRIPTION
This adds another template with support for devices where BL0937 is used for power monitoring rather than HLW8012.