### PR TITLE
Minor additions to comments with clarifications.

### DIFF
--- a/_templates/mirabella_genio_dimmable_downlight_CCT
+++ b/_templates/mirabella_genio_dimmable_downlight_CCT
@@ -10,6 +10,8 @@ template: '{"NAME":"GenioDLightCCT","GPIO":[0,0,0,0,0,0,0,0,38,0,37,0,0],"FLAG":
 link_alt: https://mirabellagenio.net.au/downlight-rgb%2Bcct
 ---
 
+Note: This is specifically for the CCT variant (Cool to warm white only) -- this template was previously marked as the RGB version.   
+A new template for the RGB+CCT (aka RGBWW) variant is at: https://blakadder.github.io/templates/mirabella_genio_dimmable_downlight_RGBCCT.html
 Flashed wirelessly using Tuya-Convert: https://github.com/ct-Open-Source/tuya-convert
 
 


### PR DESCRIPTION
-Standardising the naming of file between the CCT and RGB+CCT variant.
-Standardised comments on tuya-convert between the two variants
-Added note for those that may be confused about the two variants, especially in light of the original template being incorrectly labelled.