### PR TITLE
Updated CE Smart Home Wi-Fi Receptacle 

### DIFF
--- a/_templates/ce_wall_outlet
+++ b/_templates/ce_wall_outlet
@@ -1,12 +1,12 @@
 ---
 date: 2019-04-14
-title: Charging Essentials WiFi Smart
+title: CE Smart Home Wi-Fi Receptacle LA-2-W3
 category: plug
 type: Wall Outlet
 standard: us
-link: http://www.costco.ca 
+link: https://www.costco.ca/ce-smart-home-wi-fi-receptacle%2C-2-pack.product.100475520.html 
 image: https://i.imgur.com/8mNTQNH.png
-template: '{"NAME":"CESmart-Wall","GPIO":[255,255,255,255,255,17,255,255,21,255,255,255,255],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"CE Smart Wall","GPIO":[255,255,255,255,56,17,255,255,21,255,255,255,255],"FLAG":15,"BASE":18}' 
 link_alt: https://www.cesmarthome.com/
 ---
 


### PR DESCRIPTION
Changed product title and url to better reflect what is seen on the costco website. I initially could not find this template because the name was different from what I saw on the product packaging. Updated the template because it was missing the GPIO for the LED.