### PR TITLE
Update mirabella_genio_I002745

### DIFF
--- a/_templates/mirabella_genio_I002745
+++ b/_templates/mirabella_genio_I002745
@@ -6,11 +6,11 @@ type: Bulb
 standard: anzac
 link: https://www.kmart.com.au/product/mirabella-genio-wi-fi-dimmable-5.5w-led-candle-bulb/2746326
 image: https://www.kmart.com.au/wcsstore/Kmart/images/ncatalog/sz/0/42800590-1-sz.jpg
-template: '{"NAME":"Genio Candle","GPIO":[0,0,0,0,140,37,0,0,38,142,141,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"Mirabella Candle","GPIO":[0,0,0,0,0,0,0,0,38,0,37,0,0],"FLAG":0,"BASE":18}' 
 link_alt: https://mirabellagenio.net.au/ses-led-candle
 ---
 
-Flashed with Tuya-Convert v1
+Flashed with Tuya-Convert 2
 
 
 


### PR DESCRIPTION
The template provided does not work to control the white led channel, and I believe has RGB channel config that is not needed for this bulb.

The corrected template is known to be working on bulbs in my possession and controls brightness and white/yellow channel correctly.