### PR TITLE
Update kogan_smarterhome_10W-B22

### DIFF
--- a/_templates/kogan_smarterhome_10W-B22
+++ b/_templates/kogan_smarterhome_10W-B22
@@ -1,12 +1,12 @@
 ---
 date: 2019-10-31
-title: Kogan SmarterHome™ 10W B22 RGBW
+title: Kogan SmarterHome™ 10W RGBW
 category: light
 type: Bulb
 standard: anzac
 link: https://www.kogan.com/au/buy/kogan-smarterhome-10w-ambient-rgbw-smart-bulb-b22/
 image: https://images.kogan.com/image/fetch/s--cCIFFKHQ--/b_white,c_pad,f_auto,h_800,q_auto:good,w_1200/https://assets.kogan.com/files/product/SmartBulbs/KASB10RB22HA_2.jpg
-template: '{"NAME":"Kogan RGB","GPIO":[0,0,0,0,140,37,0,0,0,0,0,141,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"Kogan RGB","GPIO":[0,0,0,0,140,37,0,0,0,0,141,0,0],"FLAG":0,"BASE":18}' 
 link_alt: 
 ---
 


### PR DESCRIPTION
The reference to 141 SM16716 DAT is incorrect by 1 position - should be on GPIO 14, not 15.

Amended config confirmed correct and working with bulbs in my possession.