### PR TITLE
Update medion_life_S85225

### DIFF
--- a/_templates/medion_life_S85225
+++ b/_templates/medion_life_S85225
@@ -6,7 +6,7 @@ type: Plug
 standard: anzac
 link: https://aldi.com.au
 image: https://d4zzp4ohshzeb.cloudfront.net/resize/listing-picture/1b73d80f-793a-404b-9dad-ed8d3896aba9?width=1000&height=1000&withoutEnlargement=true
-template: '{"NAME":"Medion","GPIO":[0,0,0,17,134,132,0,0,131,158,21,0,0],"FLAG":0,"BASE":52}' 
+template: '{"NAME":"Medion","GPIO":[0,0,0,17,134,132,0,0,131,56,21,0,0],"FLAG":0,"BASE":52}' 
 link_alt: 
 ---
 


### PR DESCRIPTION
The power button LED on GPIO13 was listed as 158 (LEDLinki), but I got better results after changing it to 56 (LED1i). Before the change, the LED lights up when the button is pressed physically, but of course you don't see it as your finger is on the button. After the change, the LED toggles to match the state of the relay.