### PR TITLE
Update mirabella_genio_I002746

### DIFF
--- a/_templates/mirabella_genio_I002746
+++ b/_templates/mirabella_genio_I002746
@@ -6,14 +6,8 @@ type: Bulb
 standard: anzac
 link: https://www.kmart.com.au/product/mirabella-genio-wi-fi-dimmable-6w-led-light/2746327
 image: https://www.kmart.com.au/wcsstore/Kmart/images/ncatalog/sz/6/42800606-1-sz.jpg
-template: '{"NAME":"GenioGU10","GPIO":[0,0,0,0,0,0,0,0,38,0,37,0,0],"FLAG":0,"BASE":48}' 
+template: '{"NAME":"GenioGU10","GPIO":[0,0,0,0,0,0,0,0,38,0,37,0,0],"FLAG":0,"BASE":188}'
 link_alt: https://mirabellagenio.net.au/wi-fi-led-gu10
 ---
 
 Flashed with [Tuya-Convert](https://github.com/ct-Open-Source/tuya-convert)
-
-
-
-
-
-


### PR DESCRIPTION
The flag base 48 is incorrect causing the light to not completely power off when turned off, the warm the warm white LEDs stay lit, only the cool white LEDs switch off.

Correct flag base is 18, can confirm with 2 lights in my possession I have tested with.