### PR TITLE
Update mirabella_genio__I002578

### DIFF
--- a/_templates/mirabella_genio__I002578
+++ b/_templates/mirabella_genio__I002578
@@ -6,7 +6,7 @@ type: Power Strip
 standard: anzac
 link: https://www.kmart.com.au/product/mirabella-genio-wi-fi-powerboard-with-usb-ports/2736803
 image: https://www.kmart.com.au/wcsstore/Kmart/images/ncatalog/f/4/42769484-1-f.jpg
-template: '{"NAME":"Genio Powerboa","GPIO":[26,52,0,0,21,25,0,0,24,17,23,22,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"Genio Powerboa","GPIO":[21,52,0,0,23,22,0,0,25,17,26,24,0],"FLAG":0,"BASE":18}' 
 link_alt: 
 ---
 


### PR DESCRIPTION
Adjust relay order to work from Left to Right as one looks at the powerboard with the earth socket facing downwards (standard Australia/NZ orientation)