### PR TITLE
Use LedLink

### DIFF
--- a/_templates/ce_smart_home_LA-2-W3
+++ b/_templates/ce_smart_home_LA-2-W3
@@ -6,7 +6,7 @@ type: Wall Outlet
 standard: us
 link: https://www.costco.ca/ce-smart-home-wi-fi-receptacle%2C-2-pack.product.100475520.html 
 image: https://user-images.githubusercontent.com/5904370/68096689-ce487680-feb2-11e9-8f9b-a84bf7d19766.png
-template: '{"NAME":"CE Smart Wall","GPIO":[255,255,255,255,56,17,255,255,21,255,255,255,255],"FLAG":15,"BASE":18}' 
+template: '{"NAME":"CE Smart Wall","GPIO":[255,255,255,255,157,17,255,255,21,255,255,255,255],"FLAG":15,"BASE":18}' 
 link_alt: https://www.cesmarthome.com/LA-2-W3.html
 ---
 


### PR DESCRIPTION
Using LedLink (157) for GPIO4 shows WiFi status on the leftmost LED, maintaining functionality of the other two (power and relay on)