### PR TITLE
Added alternate template for Slitinto NX-SM112 16A UK power monitoring sockets.

### DIFF
--- a/_templates/stilinto_NX-SM112
+++ b/_templates/stilinto_NX-SM112
@@ -7,14 +7,20 @@ standard: uk
 link: https://www.amazon.co.uk/gp/product/B07R14VCKN
 image: https://images-na.ssl-images-amazon.com/images/I/51kx5VwKhRL._AC_SL1200_.jpg
 template: '{"NAME":"NX-SM112","GPIO":[158,0,0,131,0,134,0,0,0,17,132,21,0],"FLAG":0,"BASE":45}' 
-link_alt: 
+link_alt: https://www.amazon.co.uk/Compatible-SLITINTO-Monitoring-Schedule-Control/dp/B07R4W7KCM
+link_alt: https://www.amazon.co.uk/bakibo-Compatible-Monitoring-Schedule-Control/dp/B07R48KSWK
 ---
 
 There seems to be a couple versions of these. Same model number but different internals.
 If the above does not work, an alternative template is:
 
 ```lua
- {""NAME"":""NX-SM112"",""GPIO"":[0,0,0,131,134,132,0,0,158,17,0,21,0],""FLAG"":0,""BASE"":45}
+  {"NAME":"NX-SM112","GPIO":[0,0,0,131,134,132,0,0,158,17,0,21,0],"FLAG":0,"BASE":45}
+```
+or
+
+```lua
+ {"NAME":"NX-SM112","GPIO":[158,0,0,131,134,132,0,0,0,17,0,21,0],"FLAG":0,"BASE":45}
 ```
 
 These are a smaller form factor plug which do not foul the switch on UK sockets.


### PR DESCRIPTION
Added third template I used to get my Slitinto sockets working. Also removed double quotes on the 2nd template as they don't appear to be required. Also added a couple of alternate product links.