### PR TITLE
Fix deltaco_SH-P01E

### DIFF
--- a/_templates/deltaco_SH-P01E
+++ b/_templates/deltaco_SH-P01E
@@ -6,6 +6,6 @@ type: Plug
 standard: eu
 link: https://www.deltaco.se/produkter/deltaco/smart-home/grenuttag/SH-P01E
 image: https://www.deltaco.se/sites/cdn/PublishingImages/Products/SH-P01E.png?width=260
-template: {"NAME":"DELTACO SH-P01","GPIO":[0,0,0,0,0,56,0,0,21,17,0,0,0],"FLAG":0,"BASE":18}  
+template: {"NAME":"DELTACO SH-P01E","GPIO":[0,56,0,17,134,132,0,0,131,57,21,0,0],"FLAG":0,"BASE":55} 
 link2: https://www.webhallen.com/se/product/309650-Deltaco-WiFi-Smart-Plug-Energiovervakning-10A
 ---


### PR DESCRIPTION
In commit db1903b7c0f08d0edec9469aa6d5c9531ca1fb53 blakadder appears to have replaced the Deltaco SH-P01E template with Deltaco SH-P01 (a different product without energy sensor).
Back then this file was named templates/delock_SH-P01E .
This pull request reverts that change.
https://github.com/blakadder/templates/commit/db1903b7c0f08d0edec9469aa6d5c9531ca1fb53#r36278932
