### PR TITLE
Easier way to do this

### DIFF
--- a/_templates/ledenet
+++ b/_templates/ledenet
@@ -22,22 +22,17 @@ link2:
 
 The LEDEnet Controller has all of the serial IO pins broken out and labeled. Makes flashing very easy to do. 
 
-However, the device does require some specific steps to get it to flash in the first place. 
+connect FTDI ----> device:
 
-It took forever to figure this out, but to flash/program it:
-- Hold the button (by the LED) while applying power.
-  - GPIO0 (center pad on back) doesn't matter at this point, ignore it for now. 
-- The controller should be in "Flash Mode" now; but the LEDs (on the device) will still appear "normal". 
-- Start the flashing process; I used the normal `sonoff.bin` file (516KB).
-  - `sonoff.bin` worked fine on my version of the controller
-  - `sonoff-classic.bin` might be required if there are size issues. 
-  - `esp_1024` images also exist, they're all smaller than 512KB
-- Command Line: `python3.6 -m esptool --port /dev/tty.usbserial-(xxxxx) write_flash 0x0 whatever.bin`
-- Or use the excellent [NodeMCU PyFlasher](https://github.com/marcelstoer/nodemcu-pyflasher)
-- After the flash succeeds, you'll need to take the lead you soldered to GPIO0 (labeled as IO on my board), and tap it to ground 4 times quickly. 
-- This forces the controller to start broadcasting the configuration SSID (it might reset the controller, or something else, unsure my Serial cable didn't pick up any log messages)
-- Now you can connect and enter your WiFI credentials
+GND ----> GND
+GND ----> I0 (GPIO0)
+RX ------> TX
+TX ------> RX
+3v ----> 3v
 
-[Instructions Based on this Amazon Review](https://www.amazon.com/gp/customer-reviews/R380TIPJMY455A/ref=cm_cr_dp_d_rvw_btm?ie=UTF8&ASIN=B01DY56N8U#wasThisHelpful)
+connect FTDI to USB
+Flash BIN with NodeMCU PYflasher
+Disconnect FTDI from USB – keep only 3V/ground, reconnect FTDI
+connect Wifi to new "Tasmota" AP
+192.168.4.1 - configure. done.
 
-Credit to M. Holstein on Amazon. 


### PR DESCRIPTION
Just flashed the same device;
easier way to do this:

connect FTDI ----> device:

GND ----> GND
GND ----> I0 (GPIO0)
RX ------> TX
TX ------> RX
3v ----> 3v

connect FTDI to USB
Flash BIN with NodeMCU PYflasher
Disconnect FTDI from USB – keep only 3V/ground, reconnect FTDI
connect Wifi to new "Tasmota" AP
192.168.4.1 - configure. done.