### PR TITLE
Delock 11826: Improve LED handling

### DIFF
--- a/_templates/delock_11826
+++ b/_templates/delock_11826
@@ -6,11 +6,7 @@ type: Plug
 standard: eu
 link: https://www.delock.com/produkte/H/11826/merkmale.html
 image: https://bilder.tragant.de/produkte/orig/5cd3e170704344.60311973.jpg
-template: {"NAME":"Delock 11826","GPIO":[17,0,0,0,0,0,0,0,21,56,0,0,0],"FLAG":0,"BASE":1} 
+template: {"NAME":"Delock 11826","GPIO":[17,0,0,0,0,0,0,0,21,158,0,0,0],"FLAG":0,"BASE":1}
 link2: 
 ---
-
-
-
-
 


### PR DESCRIPTION
The Delock 11826 has a dedicated power LED (red) that is
linked to the relay in hardware.
So we can change the GPIO from Led1i to LedLinki.