### PR TITLE
Update aisirer-JH-G01B

### DIFF
--- a/_templates/aisirer-JH-G01B
+++ b/_templates/aisirer-JH-G01B
@@ -6,7 +6,7 @@ type: Plug
 standard: uk
 link: https://www.amazon.co.uk/AISIRER-Control-Compatible-British-Standards/dp/B07Y53MBGN/
 image: https://images-na.ssl-images-amazon.com/images/I/51q6upbpWVL._SY355_.jpg
-template: '{"NAME":"AISIRER","GPIO":[0,0,0,0,56,0,0,0,21,17,0,0,0],"FLAG":1,"BASE":18}' 
+template: '{"NAME":"AISIRER","GPIO":[0,0,0,0,21,0,0,0,56,17,0,0,0],"FLAG":1,"BASE":18}' 
 link2: 
 ---
 


### PR DESCRIPTION
In the original version, both the LED and relay were ON when the output (and HA) said it was OFF, and vice versa
Swapping the positions of 56 and 21 around fixes this.
However, the button on the device is not working so I suspect the "17" is in the wrong place - need further investigation.