### PR TITLE
Improve MI-BW904-999W template

### DIFF
--- a/_templates/merkury-MI-BW904-999W
+++ b/_templates/merkury-MI-BW904-999W
@@ -5,7 +5,7 @@ category: bulb
 standard: e26
 link: https://www.walmart.com/ip/Merkury-Innovations-A21-Smart-Light-Bulb-75W-Color-LED-1-Pack/254063201
 image: https://i5.walmartimages.com/asr/e15b4ae9-a1b0-4a6b-a93a-b818ee4858f2_1.1eeae0645b5aae960d7c57f7689c242a.jpeg
-template: '{"NAME":"MI-BW904-999W","GPIO":[0,0,0,0,140,37,0,0,0,142,141,0,0],"FLAG":1,"BASE":69}'
+template: '{"NAME":"MI-BW904-999W","GPIO":[0,0,0,0,140,37,0,0,38,142,141,0,0],"FLAG":1,"BASE":69}'
 ---
 
 


### PR DESCRIPTION
MI-BW904-999W has a separate channel for warm white. (and maybe an other one for cold white ?)
With this change users can use at least warm white and get the full light working (1050 lumens) with white only (no color)