### PR TITLE
Update naamasmart_KS602

### DIFF
--- a/_templates/naamasmart_KS602
+++ b/_templates/naamasmart_KS602
@@ -6,8 +6,8 @@ type: Switch
 standard: us
 link: https://www.amazon.com/gp/product/B077M5FN9M
 image: https://images-na.ssl-images-amazon.com/images/I/216LMI6KgZL.jpg
-template: '{"NAME":"KS-602","GPIO":[17,0,0,0,0,0,0,0,21,0,0,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"KS-602","GPIO":[17,0,0,0,0,0,0,0,21,158,0,0,0],"FLAG":0,"BASE":18}' 
 link2: 
 ---
 
-Easily converted with Tuya-Convert
+Easily converted with Tuya-Convert. LED will blick with no connection and be off when there is one. If it is wanted to be on for on-line, simply change GPIO13 to LedLink.


### PR DESCRIPTION
Template didn't make use if the WiFi indicator LED at all. My change makes it blink when no connectivity and off when there is.  I updated the description to note that reversing the GPIO13 from LedLinki to LedLink will turn on the indicator always if wanted.  This depends if the user wants their switches glowing wifi indicators all over their home (I do not). Feel free to reverse that and the description if you feel it better.