### PR TITLE
updated to add template that is working for costco us

### DIFF
--- a/_templates/feit_electric-BPA800RGBWAG2
+++ b/_templates/feit_electric-BPA800RGBWAG2
@@ -6,7 +6,7 @@ category: bulb
 standard: e26
 link2: https://www.costco.com/Feit-WiFi-Smart-Bulbs%2c-4-pack.product.100417461.html
 image: https://www.feit.com/wp-content/uploads/2018/05/BPA800_RGBW_AG_2_pack-1.jpg
-template: '{"NAME":" BPA800/RGBW","GPIO":[0,0,0,0,37,38,0,0,141,142,140,0,0],"FLAG":0,"BASE":48}' 
+template: '{"NAME":" BPA800/RGBW","GPIO":[0,0,0,0,37,38,0,0,141,142,140,0,0],"FLAG":0,"BASE":48} or {"NAME":"OM60/RGBW","GPIO":[0,0,0,0,140,37,0,0,38,142,141,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.amazon.com/Electric-Assistant-A800-RGBW-AG/dp/B07RL48PFF
 link3: https://www.feit.com/product/smart-wifi-bulb-color-changing-tunable-white/
 ---
@@ -15,6 +15,7 @@ This bulb seems to have hardware Gamma correction, so you need to make sure you 
 
 `LedTable 0`
 
+If you use the second template, run `setoption37 54` from the console. It will correct the blue - red mismatch
 
 
 


### PR DESCRIPTION
I bought a bunch of these from Costco last year and all of them work w/ the template (which I found on https://github.com/ct-Open-Source/tuya-convert/issues/99 see comment at the end) 

The current template marked on this page only worked for the new bulbs I picked up from Costco yesterday.

