### PR TITLE
added variant for feit bpa800/rgbw/ag2

### DIFF
--- a/_templates/feit_electric-BPA800RGBWAG2
+++ b/_templates/feit_electric-BPA800RGBWAG2
@@ -6,9 +6,11 @@ category: bulb
 standard: e26
 link2: https://www.costco.com/Feit-WiFi-Smart-Bulbs%2c-4-pack.product.100417461.html
 image: https://www.feit.com/wp-content/uploads/2018/05/BPA800_RGBW_AG_2_pack-1.jpg
-template: '{"NAME":" BPA800/RGBW/AG/2","GPIO":[0,0,0,0,140,37,0,0,38,142,141,0,0],"FLAG":0,"BASE":48}' 
+template: '{"NAME":" BPA800/RGBW/AG/2","GPIO":[0,0,0,0,140,37,0,0,38,142,141,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.amazon.com/Electric-Assistant-A800-RGBW-AG/dp/B07RL48PFF
 link3: https://www.feit.com/product/smart-wifi-bulb-color-changing-tunable-white/
 ---
 
 Run `setoption37 54` from the console to correct the red - blue mismatch.
+
+**NOTE:** There are two variants of this bulb, BPA800/RGBW/AG/2(P) and BPA800/RGBW/AG/2. 

--- a/_templates/feit_electric-BPA800RGBWAG2
+++ b/_templates/feit_electric-BPA800RGBWAG2
@@ -6,15 +6,9 @@ category: bulb
 standard: e26
 link2: https://www.costco.com/Feit-WiFi-Smart-Bulbs%2c-4-pack.product.100417461.html
 image: https://www.feit.com/wp-content/uploads/2018/05/BPA800_RGBW_AG_2_pack-1.jpg
-template: '{"NAME":" BPA800/RGBW","GPIO":[0,0,0,0,37,38,0,0,141,142,140,0,0],"FLAG":0,"BASE":48}' 
+template: '{"NAME":" BPA800/RGBW/AG/2","GPIO":[0,0,0,0,140,37,0,0,38,142,141,0,0],"FLAG":0,"BASE":48}' 
 link: https://www.amazon.com/Electric-Assistant-A800-RGBW-AG/dp/B07RL48PFF
 link3: https://www.feit.com/product/smart-wifi-bulb-color-changing-tunable-white/
 ---
 
-This bulb seems to have hardware Gamma correction, so you need to make sure you disable Software Gamma Correction:
-
-`LedTable 0`
-
-
-
-
+Run `setoption37 54` from the console to correct the red - blue mismatch.

--- a/_templates/feit_electric-BPA800RGBWAG2P
+++ b/_templates/feit_electric-BPA800RGBWAG2P
@@ -1,0 +1,18 @@
+---
+date_added: 2020-01-01
+title: Feit Electric BPA800/RGBW/AG/2(P) 800lm
+type: RGBW
+category: bulb
+standard: e26
+link2: https://www.costco.com/Feit-WiFi-Smart-Bulbs%2c-4-pack.product.100417461.html
+image: https://www.feit.com/wp-content/uploads/2018/05/BPA800_RGBW_AG_2_pack-1.jpg
+template: '{"NAME":" BPA800/RGBW","GPIO":[0,0,0,0,37,38,0,0,141,142,140,0,0],"FLAG":0,"BASE":48}' 
+link: https://www.amazon.com/Electric-Assistant-A800-RGBW-AG/dp/B07RL48PFF
+link3: https://www.feit.com/product/smart-wifi-bulb-color-changing-tunable-white/
+---
+
+This bulb seems to have hardware Gamma correction, so you need to make sure you disable Software Gamma Correction:
+
+`LedTable 0`
+
+**NOTE:** There are two variants of this bulb, BPA800/RGBW/AG/2(P) and BPA800/RGBW/AG/2. 

--- a/_templates/feit_electric-BPA800RGBWAG2P
+++ b/_templates/feit_electric-BPA800RGBWAG2P
@@ -6,7 +6,7 @@ category: bulb
 standard: e26
 link2: https://www.costco.com/Feit-WiFi-Smart-Bulbs%2c-4-pack.product.100417461.html
 image: https://www.feit.com/wp-content/uploads/2018/05/BPA800_RGBW_AG_2_pack-1.jpg
-template: '{"NAME":" BPA800/RGBW","GPIO":[0,0,0,0,37,38,0,0,141,142,140,0,0],"FLAG":0,"BASE":48}' 
+template: '{"NAME":" BPA800/RGBW/AG/2P","GPIO":[0,0,0,0,37,38,0,0,141,142,140,0,0],"FLAG":0,"BASE":48}' 
 link: https://www.amazon.com/Electric-Assistant-A800-RGBW-AG/dp/B07RL48PFF
 link3: https://www.feit.com/product/smart-wifi-bulb-color-changing-tunable-white/
 ---


### PR DESCRIPTION
I have about 20 of these bulbs. I purchased all of them from Costco US at different times. It seems that there are two variants sold in the same packaging. 

1. BPA800/RGBW/AG/2
1. BPA800/RGBW/AG/2(P)

The 1st variant works with:
`{"NAME":"OM60/RGBW","GPIO":[0,0,0,0,140,37,0,0,38,142,141,0,0],"FLAG":0,"BASE":18}`
`setoption37 54 `

The (P) variant works with
`{"NAME":" BPA800/RGBW","GPIO":[0,0,0,0,37,38,0,0,141,142,140,0,0],"FLAG":0,"BASE":48}`
`LedTable 0` 

