### PR TITLE
This variant doesn't need LedTable 0

### DIFF
--- a/_templates/feit_electric-BPA800RGBWAG2
+++ b/_templates/feit_electric-BPA800RGBWAG2
@@ -12,10 +12,5 @@ link3:
 ---
 **NOTE:** There are two variants of this bulb, [BPA800/RGBW/AG/2(P)](feit_electric-BPA800RGBWAG2P) and BPA800/RGBW/AG/2 (this template). 
 
-This bulb seems to have hardware Gamma correction, so you need to make sure you disable Software Gamma Correction:
-
-`LedTable 0`
-
-
-
+Need to run `setoption37 54` to correct the RED and BLUE mismatch
 


### PR DESCRIPTION
This variant doesn't need `LedTable 0`
It does need `setoption37 54` to get the red-blue to work correctly