### PR TITLE
Update and rename lsc_smart_connect_MR16 to lsc_smart_connect_GU10

### DIFF
--- a/_templates/lsc_smart_connect_GU10
+++ b/_templates/lsc_smart_connect_GU10
@@ -1,6 +1,6 @@
 ---
 date_added: 2019-10-21
-title: LSC Smart Connect MR16 380lm
+title: LSC Smart Connect GU10 5W 380lm
 type: RGBW
 category: bulb
 standard: gu10


### PR DESCRIPTION
The old version suggested its an MR16 bulb (12V with thin pins just like the G4 halogen)
But it is a GU10 bulb (230V thick pins with an extra locking thicker part at the bottom)
Also added the power (I have this bulb and it says 5 watt on the packaging)