### PR TITLE
Restore default led behavior

### DIFF
--- a/_templates/gosund_SP112
+++ b/_templates/gosund_SP112
@@ -6,14 +6,14 @@ type: Plug
 standard: eu
 link: https://www.amazon.de/gp/product/B07PMW88L7
 image: https://user-images.githubusercontent.com/5904370/66715805-e8b59580-edc7-11e9-954e-dfd45c1fc07e.png
-template: '{"NAME":"SHP5","GPIO":[56,145,57,146,255,22,0,0,255,255,21,255,18],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"SHP5","GPIO":[57,145,56,146,255,22,0,0,255,255,21,255,18],"FLAG":0,"BASE":18}' 
 link2: https://www.amazon.de/gp/product/B07PPZS351
 link3: https://gosund.com/download/smart_plug/127.html
 ---
 
 Button will toggle the USB Output. If you want to toggle the Relays, use this template: 
 ```console
-{"NAME":"SHP5","GPIO":[56,145,57,146,255,22,0,0,255,255,21,255,17],"FLAG":0,"BASE":18}
+{"NAME":"SHP5","GPIO":[57,145,56,146,255,22,0,0,255,255,21,255,17],"FLAG":0,"BASE":18}
 ```
 
 


### PR DESCRIPTION
With the recent template, when the power is turned on, the led is lighting up blue, which is pretty annoying  especially when it's getting dark.

With the new template, if the plug is off, no light is shining and if its turned on, a pretty weak red light is shining. With this it's no problem to use it in the sleeping room.