### PR TITLE
Add HLW8012 based power monitoring to 35511

### DIFF
--- a/_templates/stitch_35511
+++ b/_templates/stitch_35511
@@ -6,7 +6,7 @@ type: Plug
 standard: us
 link: https://www.monoprice.com/product?p_id=35511
 image: https://images.monoprice.com/productlargeimages/355111.jpg
-template: '{"NAME":"Stitch 35511","GPIO":[56,0,57,0,0,0,0,0,0,17,0,21,0],"FLAG":1,"BASE":18}' 
+template: '{"NAME":"Stitch 35511","GPIO":[56,0,57,0,0,133,0,0,0,17,132,21,131],"FLAG":0,"BASE":18}' 
 link2: 
 ---
 


### PR DESCRIPTION
Page also needs the "For more accurate energy consumption measurements this device requires power monitoring calibration." line but not sure if the site auto adds that.