### PR TITLE
Update neo_coolcam_NAS-IR03W0

### DIFF
--- a/_templates/neo_coolcam_NAS-IR03W0
+++ b/_templates/neo_coolcam_NAS-IR03W0
@@ -3,7 +3,7 @@ date_added: 2020-01-15
 title: NEO Coolcam NAS-IR03W0
 model: 
 image: https://user-images.githubusercontent.com/5904370/72420706-816d0000-377f-11ea-9276-b398f35aed67.png
-template: '{"NAME":"Neo Coolcam NA","GPIO":[0,0,0,0,8,51,0,0,0,17,56,0,0],"FLAG":0,"BASE":62}' 
+template: '{"NAME":"Neo Coolcam IR","GPIO":[0,0,0,0,56,51,0,0,0,17,8,0,0],"FLAG":0,"BASE":62}' 
 link: https://www.aliexpress.com/af/neo-coolcam-ir-remote.html
 link2: https://www.ebay.com.au/itm/Smart-IR-WiFi-Home-Remote-Control-Compatible-Fit-For-TV-Air-Conditioner-Lamp-AU/223758299689
 link3: https://szneo.com/en/products/show.php?id=231


### PR DESCRIPTION
I accidentally flipped the GPIO 4 and 14 by accident and also needed to update the name to "Neo Coolcam IR" from "Neo Coolcam NA" as there was a space limitation I was not originally aware of.