### PR TITLE
Change GPIO0 from Switch1 (9) to Button1 (17)

### DIFF
--- a/_templates/kuled-ks602s
+++ b/_templates/kuled-ks602s
@@ -6,7 +6,7 @@ type: Switch
 standard: us
 link: https://www.amazon.com/Required-Wireless-Requires-Schedule-Compatible/dp/B079FDTG7T
 image: https://user-images.githubusercontent.com/5904370/53685150-53253400-3d17-11e9-9dbb-0c868db95e11.png
-template: '{"NAME":"KULED","GPIO":[9,255,255,255,255,255,0,0,21,56,255,255,255],"FLAG":0,"BASE":18}'
+template: '{"NAME":"KULED","GPIO":[17,255,255,255,255,255,0,0,21,56,255,255,255],"FLAG":0,"BASE":18}'
 link2:
 ---
 Easily flashable with Tuya Convert 


### PR DESCRIPTION
When using Tasmota 8.1.0 at least and just applying the template with Switch1 (9) the device when physically pressed will turn on and off again immediately. Other commands can be added in the Tasmota console to make the device work with Switch1. But changing to a Button1 (17) in the template will allow this device to work by just applying the template. Using Button1 will allow the physical device to toggle on and off with each physical press.