### PR TITLE
Added tuya-convert and additional datafield to PC-WKS 1167

### DIFF
--- a/_templates/proficook_PC-WKS_1167
+++ b/_templates/proficook_PC-WKS_1167
@@ -8,11 +8,14 @@ link: https://www.amazon.de/Wasserkocher-kostenlose-programmierbare-Temperaturre
 link2: https://www.conrad.com/p/profi-cook-pc-wks-1167-g-tea-maker-stainless-steel-glass-1974778
 mlink: https://www.proficook.de/products/en/New-products/PC-WKS-1167G-Glass-tea-kettle.html
 flash: serial
+flash2: tuya-convert
 category: misc
 type: Kettle
 standard: eu
 ---
 When flashing via serial connection remember to pull the TuyaMCU Reset Pin to ground. It's a HR7P169BFGSF from Easysoft so pin 4 must be connected to ground. Device sends data on DpId 101,105,106,107,108.
+
+When flashing using tuya-convert press and hold 45°C button for 5 seconds to enter fast flashing mode and follow the normal tuya-convert procedure.
 
 - `TuyaSend4 101,0` is for 45 degrees
 - `TuyaSend4 101,1` is for 60 degrees 
@@ -22,10 +25,11 @@ When flashing via serial connection remember to pull the TuyaMCU Reset Pin to gr
 - `TuyaSend4 101,6` resets the temperature and puts the kettle into idle.
 It is required to send a 101,6 command if you want to switch form one temperature to another. 
 
-The state of the kettle is stored under DpId 106 Datafield
-Datafield 1 means kettle removed
-Datafield 2 means kettle placed on base
-Datafield 3 means heating
+The state of the kettle is stored under DpId 106 Datafield (DpIdData)
+Datafield 01 means kettle removed
+Datafield 02 means kettle placed on base (idle state)
+Datafield 03 means heating
+Datafield 05 means maintaining selected temperature
 
 The temperature of the water is reported via DpId 105 Datafield (hex!) 
 


### PR DESCRIPTION
Is the following syntax appropriate for including two different flashing options?
```
flash: serial
flash2: tuya-convert
```