### PR TITLE
Lumary LED strips no longer have ESP8266 chips

### DIFF
--- a/_templates/lumary_led_strip-us
+++ b/_templates/lumary_led_strip-us
@@ -11,3 +11,5 @@ category: light
 type: LED Strip
 standard: us
 ---
+
+Newer versions of the controller in this set no longer contain an ESP-82** chip, instead containing a WR3E, which is not compatible with Tasmota.


### PR DESCRIPTION
Source: pulling open a Lumary LED strip purchased on Jan 30, 2020 from Amazon US. Also found a reddit post reporting same situation:
https://www.reddit.com/r/homeautomation/comments/esjgq7/led_multicolor_light_strips_wtasmota_suggestions/