### PR TITLE
Switch of warm and cold LEDs to fix CT commands

### DIFF
--- a/_templates/globe_34919
+++ b/_templates/globe_34919
@@ -3,7 +3,7 @@ date_added: 2020-02-06
 title: Globe 34919 ST19 Edison 500lm
 model: 34919
 image: /assets/images/globe_34919.jpg
-template: '{"NAME":"Globe 34919","GPIO":[0,0,0,0,0,0,0,0,37,0,38,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"Globe 34919","GPIO":[0,0,0,0,0,0,0,0,38,0,37,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.amazon.com/dp/B081472HZY
 link2: 
 mlink: https://globe-electric.com/en/product/globe-electric-wi-fi-smart-60w-equivalent-vintage-filament-tunable-white-dimmable-amber-glass-led-light-bulb-no-hub-required-voice-activated-st19-shape-e26-base-34919/


### PR DESCRIPTION
The internal LEDs that turn on and off should be switched. The command `CT 153` should only light the cool white and `CT 500` should only light the warm white bulb. The current template does the opposite of what is intended.