### PR TITLE
Shelly RGBW2: Update template to dimmable RGB

### DIFF
--- a/_templates/shelly_RGBW2
+++ b/_templates/shelly_RGBW2
@@ -6,15 +6,9 @@ type: LED Controller
 standard: eu
 link: https://shelly.cloud/wifi-smart-shelly-rgbw-2/
 image: https://shelly.cloud/wp-content/uploads/2018/11/RGBWv2_top.jpg
-template: '{"NAME":"RGBW2","GPIO":[255,255,33,255,24,91,0,0,21,17,23,22,255],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"Shelly RGBW2","GPIO":[0,0,52,0,40,255,0,0,37,17,39,38,0],"FLAG":0,"BASE":18}' 
 link: https://www.amazon.de/dp/B07N49TXLQ/
 link2: https://www.amazon.com/Shelly-Controller-Wireless-Automation-Schedule/dp/B07N49TXLQ 
 ---
-
-
-
-
-
-
-
-
+To make use of the Input clamp of the device you need to set GPIO5 as Button2n. 
+However this could cause some instability.


### PR DESCRIPTION
I had some problems with the current template of Shelly RGBW2. The leds are not dimmable (they are with the original firmware) and the device would reboot a few minutes after loading the tempalate. These changed fixed my problems.

This includes the following changes:
- Added "Shelly" to the template name
- Changed not connected to None
- Change status led from relay to led
- Changed button2 to user, as this would reboot my device
- Use PWM instead of Relay to make the led strip dimmable

