### PR TITLE
Removing amazon link

### DIFF
--- a/_templates/lohas-ZN001
+++ b/_templates/lohas-ZN001
@@ -7,7 +7,6 @@ standard: e26
 link2: https://www.lohas-led.com/lohas-smart-led-bulb-a19-e26-810lm-60w-equivalent9w-rgb-dimmable-alexa-google-home-and-siri-compatible4-pack-p0232-p0232.html
 image: https://www.lohas-led.com/u_file/1911/products/11/08ca642826.jpg.640x640.jpg
 template: '{"NAME":"Lohas RGBW","GPIO":[0,0,0,0,0,0,0,0,0,143,0,144,0],"FLAG":0,"BASE":18}'
-link: https://www.amazon.com/LED-LOHAS-Daylight-Changing-Equivalent/dp/B07T7W7ZMW
 mlink: https://www.lohasled.com/9w-a19-p00064p1.html
 ---
 


### PR DESCRIPTION
This bulb is not available on amazon, the on that is on amazon is https://templates.blakadder.com/lohas-ZN033.html

Note product # difference: LH-APP-W9-E26-4 vs LH-APPW9-E26-4