### PR TITLE
Update makegood_MG-UKWSWB

### DIFF
--- a/_templates/makegood_MG-UKWSWB
+++ b/_templates/makegood_MG-UKWSWB
@@ -13,6 +13,12 @@ standard: uk
 ---
 Other manufacturer IDs: HX-U5pinW/B or Hi-UK5PinWFWS01W
 
-I based this loosely on the MakeGood template found here and made some changes. The only thing I did not manage to get working is the low blue LED light when the socket is switched off. LED for power on works fine.
+I based this loosely on the MakeGood template found here and made some changes. The only thing I did not manage to get working is the low blue LED light when the socket is switched off*. LED for power on works fine.
 
 Also be sure to run the commands: `SwitchMode1 5` and `SwitchMode2 5`
+
+Dim led light when off feature added by anudu on 2020_02_17
+FOR LED BEHIND TOUCH SWICH TO DIM WHEN OFF AND 100% BRIGHT WHEN ON
+use template (changes LED1i to PWM1i)
+template: '{"NAME":"Aseer 1-Gang","GPIO":[56,0,157,57,134,132,0,0,131,0,0,21,9],"FLAG":0,"BASE":18}
+and the commands `SwitchMode1 5` , `SwitchMode2 5` ,  'rule1 on power1#state=1 do dimmer 100 endon on power1#state=0 do dimmer 10 endon' and 'rule1 1'


### PR DESCRIPTION
LED behind touch sensor will dim to 10% when off and then to 100% when on. This will help locate the switch in the dark when it is off.