### PR TITLE
GPIO16 update

### DIFF
--- a/_templates/heltec_wifi_kit_8
+++ b/_templates/heltec_wifi_kit_8
@@ -6,7 +6,7 @@ type: DIY
 standard: global
 mlink: https://heltec.org/project/wifi-kit-8/
 image: https://i2.wp.com/heltec.org/wp-content/uploads/2019/04/SAM_0658_800X800-1.png
-template: '{"NAME":"HTIT-W8266","GPIO":[255,255,255,255,6,5,0,0,255,255,255,255,255],"FLAG":15,"BASE":18}' 
+template: '{"NAME":"HTIT-W8266","GPIO":[255,255,255,255,6,5,0,0,255,255,255,255,162],"FLAG":15,"BASE":18}' 
 link: https://www.amazon.com/MakerFocus-ESP8266-Development-Display-Support/dp/B076JDVRLP/
 link2: https://robotzero.one/heltec-wifi-kit-8/
 ---
@@ -17,7 +17,10 @@ DisplayModel 2
 DisplayHeight 32
 DisplayAddress 60
 ```
-I had to wire a 1K resistor between GPIO16 and RST to get the display to work reliably. You will of course need to use a Tasmota build that supports displays.
+
+Note: since version 8.1.0.3, there is no need to wire a 1K resistor between GPIO16 and RST anymore, just configure `GPIO16` as `OLED Reset`
+
+You will of course need to use a Tasmota build that supports displays.
 
 
 


### PR DESCRIPTION
Starting from 8.1.0.3, `GPIO16` can now be defined as `OLED Reset` and there is no need anymore for a resistor between GPIO16 and RST.