### PR TITLE
Update aoycocr_SW1

### DIFF
--- a/_templates/aoycocr_SW1
+++ b/_templates/aoycocr_SW1
@@ -3,7 +3,7 @@ date_added: 2019-12-23
 title: Aoycocr SW1
 link: https://www.amazon.com/dp/B07SVD6P2L/
 image: https://images-na.ssl-images-amazon.com/images/I/51QHahlxVfL._AC_SL1200_.jpg
-template: '{"NAME":"Aoycocr SW1","GPIO":[52,255,53,255,255,255,255,255,58,17,255,21,255],"FLAG":15,"BASE":18}' 
+template: '{"NAME":"Aoycocr SW1","GPIO":[158,255,57,255,255,255,255,255,56,17,255,21,255],"FLAG":15,"BASE":18}' 
 link2: 
 mlink: 
 flash: tuya-convert
@@ -13,4 +13,4 @@ standard: us
 ---
 ![Label](https://user-images.githubusercontent.com/5904370/71768483-8e375b80-2f16-11ea-946f-2dd0ccb6c943.png)
 
-Green led light is off if the switch is off. It turns on if the switch is on. Red led light is disabled.
+Green LED is on when relay is on. Red is the LedLink (MQTT status). Blue LED is unused.


### PR DESCRIPTION
Current template is incorrect. It does not behave like the description (with Tasmota 8.1.0.x). It actually acts like the red LED is an inverted LedLink, and the blue LED is on when the relay is off (i.e. inverted relay state). The end result is that it looks like purple when off, and red when on).

This change implements LedLink, and properly inverts all LEDs.

Unfortunately there's no nice way to use the blue LED with the current Tasmota implementation, but it's there as Led2i, if someone wants to use it in rules (and accept the consequences).