### PR TITLE
Update gosund_SW1 for variant with LED on different GPIO

### DIFF
--- a/_templates/gosund_SW1
+++ b/_templates/gosund_SW1
@@ -11,3 +11,7 @@ link2:
 ---
 
 seems to be renamed KS-602S, template works perfectly
+
+Received a batch of switches purchased Feb 2020 that have the status LED moved to GPIO2 from GPIO1. needs a slightly different template:
+'{"NAME":"Gosund SW1","GPIO":[17,0,56,0,0,0,0,0,0,0,21,0,158],"FLAG":0,"BASE":18}' 
+


### PR DESCRIPTION
Unfortunately all the markings are the same so there doesn't appear to be a way to differentiate these two variants.