### PR TITLE
Update treatlife_SS02

### DIFF
--- a/_templates/treatlife_SS02
+++ b/_templates/treatlife_SS02
@@ -6,7 +6,7 @@ image: /assets/images/treatlife_SS02.jpg
 template: '{"NAME":"TreatLife 3Way","GPIO":[0,0,0,0,53,29,0,0,30,18,9,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.amazon.com/Treatlife-Compatible-Assistant-Schedule-Required/dp/B07ZSQ8R85/
 link2: 
-mlink: https://www.treatlife.tech/products/treatlife-3-way-smart-light-switch-wifi-light-switch-single-pole-3-way-switch-remote-control-works-with-alexa-google-assistant-and-ifttt-schedule-no-hub-required-etl-listed-neutral-wire-required
+mlink: https://www.amazon.com/dp/B07V4X7BRT/ref=psdc_6291359011_t2_B07ZSQ8R85
 flash: tuya-convert
 category: switch
 type: Switch


### PR DESCRIPTION
URL points to a newer version of this switch which cannot be flash with tuya-convert (not the ESP chip) which I found out the hard way.  The link I put in goes to the older version of the switch.  The replaced link should probably go with a warning in the incompatible devices section.