### PR TITLE
Harmonize LSC names and add some model numbers

### DIFF
--- a/_templates/lsc_smart_connect_A60
+++ b/_templates/lsc_smart_connect_A60
@@ -3,7 +3,7 @@ date_added: 2020-01-05
 title:  LSC Smart Connect Filament A60 
 link: https://www.action.com/de-de/p/lsc-smart-connect-slimme-filament-ledlamp--a8452df7/
 image: https://www.action.com/globalassets/cmsarticleimages/79/72/2578228_8712879142737-111_01.png
-template: '{"NAME":"LSC_Filam_E27","GPIO":[0,0,0,0,0,0,0,0,38,0,37,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"LSC Filam E27","GPIO":[0,0,0,0,0,0,0,0,38,0,37,0,0],"FLAG":0,"BASE":18}' 
 link2: https://www.action.com/nl-nl/p/lsc-smart-connect-slimme-filament-ledlamp/
 mlink: 
 flash: tuya-convert

--- a/_templates/lsc_smart_connect_C45
+++ b/_templates/lsc_smart_connect_C45
@@ -1,9 +1,10 @@
 ---
 date_added: 2019-12-24
-title: LSC Smart Connect C45 400lm 
+title: LSC Smart Connect C45 400lm
+model: 970720 v2.0
 link: https://www.action.com/de-de/p/lsc-smart-connect-slimme-multicolor-ledlamp--48e7b6db/
 image: https://www.action.com/globalassets/cmsarticleimages/79/64/2578517_8712879142713-111_01.png
-template: '{"NAME":"LSC E14 RGBW","GPIO":[0,0,0,0,0,0,0,0,181,0,180,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"LSC RGBCW E14","GPIO":[0,0,0,0,0,0,0,0,181,0,180,0,0],"FLAG":0,"BASE":18}' 
 link2: 
 mlink: 
 flash: tuya-convert

--- a/_templates/lsc_smart_connect_MR16
+++ b/_templates/lsc_smart_connect_MR16
@@ -1,12 +1,13 @@
 ---
 date_added: 2019-10-21
 title: LSC Smart Connect MR16 380lm
+model: 970702 v1.0
 type: RGBW
 category: bulb
 standard: gu10
 link: https://www.action.com/nl-nl/p/lsc-smart-connect-slimme-multicolor-spot/
 image: https://www.action.com/globalassets/cmsarticleimages/79/67/2578516_8712879142690-111_01.png
-template: '{"NAME":"LSC RGBCW LED","GPIO":[0,0,0,0,0,0,0,0,181,0,180,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"LSC RGBCW GU10","GPIO":[0,0,0,0,0,0,0,0,181,0,180,0,0],"FLAG":0,"BASE":18}' 
 link2: 
 ---
 

--- a/_templates/lsc_smart_connect_filament-C35
+++ b/_templates/lsc_smart_connect_filament-C35
@@ -3,7 +3,7 @@ date_added: 2019-12-29
 title: LSC Smart Connect Filament C35
 link: https://www.action.com/nl-nl/p/lsc-smart-connect-slimme-filament-ledlamp-5/
 image: https://www.action.com/globalassets/cmsarticleimages/79/61/2578519_8712879142720-111_01.png
-template: '{"NAME":"LSC_E14_Filame","GPIO":[0,255,0,255,0,0,0,0,38,0,37,0,0],"FLAG":15,"BASE":18}' 
+template: '{"NAME":"LSC Filam E14","GPIO":[0,255,0,255,0,0,0,0,38,0,37,0,0],"FLAG":15,"BASE":18}' 
 link2: https://www.action.com/de-de/p/lsc-smart-connect-intelligente-led-filament-lampe-6/
 mlink: 
 flash: tuya-convert

--- a/_templates/lsc_smart_connect_filament-G125
+++ b/_templates/lsc_smart_connect_filament-G125
@@ -3,7 +3,7 @@ date_added: 2020-01-05
 title: LSC Smart Connect Filament G125
 link: https://www.action.com/de-de/p/lsc-smart-connect-intelligente-led-filament-lampe-4/
 image: https://www.action.com/globalassets/cmsarticleimages/79/70/2578270_8712879142768-111.png
-template: '{"NAME":"LSC-Filam-Huge","GPIO":[0,0,0,0,0,0,0,0,38,0,37,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"LSC Filam Huge","GPIO":[0,0,0,0,0,0,0,0,38,0,37,0,0],"FLAG":0,"BASE":18}' 
 link2: https://www.action.com/nl-nl/p/lsc-smart-connect-slimme-filament-ledlamp--4aa9c59d/
 mlink: 
 flash: tuya-convert

--- a/_templates/lsc_smart_connect_filament-ST64
+++ b/_templates/lsc_smart_connect_filament-ST64
@@ -6,7 +6,7 @@ category: bulb
 standard: e27
 link: https://www.action.com/de-de/p/lsc-smart-connect-intelligente-led-filament-lampe-10/
 image: https://www.action.com/globalassets/cmsarticleimages/79/87/2578543_8712879142744-111_01.png
-template: '{"NAME":"LSC-Filam-Big","GPIO":[0,0,0,0,0,0,0,0,38,0,37,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"LSC Filam Big","GPIO":[0,0,0,0,0,0,0,0,38,0,37,0,0],"FLAG":0,"BASE":18}' 
 link2: 
 ---
 

--- a/_templates/lsc_smart_connect_led_strip
+++ b/_templates/lsc_smart_connect_led_strip
@@ -6,7 +6,7 @@ type: LED Strip
 standard: eu
 link: https://www.action.com/de-de/p/lsc-smart-connect-intelligenter-multicolor-led-strip-/
 image: https://www.action.com/globalassets/cmsarticleimages/79/81/2578634_8712879142775-111.png?preset=mediaSliderImageLarge
-template: '{"NAME":"LSC-RGBW-Strip","GPIO":[51,0,0,0,37,0,0,0,38,40,39,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"LSC RGBW Strip","GPIO":[51,0,0,0,37,0,0,0,38,40,39,0,0],"FLAG":0,"BASE":18}' 
 link2: 
 ---
 


### PR DESCRIPTION
All LSC Smart Connect entries now have the same naming format. Also added model numbers for the RGBCW bulbs.