### PR TITLE
Link to digiblur alternate firmware

### DIFF
--- a/_templates/martin_jerry-MJ-SD02
+++ b/_templates/martin_jerry-MJ-SD02
@@ -18,3 +18,6 @@ rule1 on Button3#state=2 do dimmer + endon on Button2#state=2 do dimmer - endon 
 ```console
 backlog SerialLog 0; setoption3 1; setoption1 1; setoption32 8; buttontopic 0; setoption113 1; rule1 1; module 0
 ```
+
+Alternate Tasmota firmware for these dimmers and a ruleset are here, with better results:
+https://github.com/digiblur/Tasmota


### PR DESCRIPTION
I am not sure how/if you want to address this.  I purchased this switch and, while tuya-convert worked easily to flash it, the template and rules listed failed horribly.  At one point I was sure I bricked by switch.  Digblur's alternate Tasmota firmware and setup worked beautifully on the first try.  The switch works better than I could have hoped with every button and LED matching the default firmware.  The link and instructions are here:

https://github.com/digiblur/Tasmota

I'm not even sure you want to leave it "as is" since it doesn't seem to work.  Just my opinion.