### PR TITLE
Update blitzwolf_SHP6-15A

### DIFF
--- a/_templates/blitzwolf_SHP6-15A
+++ b/_templates/blitzwolf_SHP6-15A
@@ -12,7 +12,12 @@ category: plug
 type: Plug
 standard: eu
 ---
-Different from the old SHP6 10A rated for 2300W.
+**This template is only for SHP6 15A version**. The old 10A template is [here](blitzwolf_SHP6).
+
+If you prefer the red LED to represent "Power ON", swap Led1i and LedLinki in the ***Configure Template*** page.
+
+### Serial Flash Instructions
+Complete guide on [Tasmota Wiki](https://tasmota.github.io/docs/#/devices/BlitzWolf-SHP6)
 
 ![Label](https://user-images.githubusercontent.com/5904370/72109869-1d89a800-3337-11ea-920b-5e5559cc1778.png)
 


### PR DESCRIPTION
Adding a link to the Serial Flash Instructions,
Re writing to be more inline with the 10A version template.
Adding bolt to make the distinction between versions more clear

On the 10A version template, I want to add an image of the plug at the bottom of the page like in the 15A version template (witch make it easy to see the power rating difference) but I can't figure it out.
Here is the image : https://www.blitzwolf.com/bg_os/other/upload_temp/products/original/201810/1539338191_26.jpg

Please, make sure I've not broken any hyper links. Without the github editing tool and a preview it's not as easy.