### PR TITLE
Update 2nice-UP111

### DIFF
--- a/_templates/2nice-UP111
+++ b/_templates/2nice-UP111
@@ -3,7 +3,7 @@ date_added: 2019-12-18
 title: 2nice UP111
 link: https://www.amazon.co.uk/gp/product/B07ZQ34X55
 image: /assets/images/2nice-UP111.jpg
-template: '{"NAME":"2NICE UP111","GPIO":[0,52,0,17,134,132,0,0,131,157,21,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"2NICE UP111","GPIO":[0,158,0,17,134,132,0,0,131,56,21,0,0],"FLAG":0,"BASE":18}' 
 link2: https://www.amazon.co.uk/2NICE-Compatible-Control-Anywhere-Monitoring/dp/B07ZQ7B572
 mlink: 
 flash: tuya-convert


### PR DESCRIPTION
- LedLink and Led1 swapped. The blue LED is on GPIO1 which works better as LedLink and the red LED is on GPIO13 which works better as Led1.
- Both LEDs set as active low (LedLinki and Led1i) so that the red LED is on when the plug is on, and the blue LED is on when indicating wireless activity, issues, etc.

Thanks!