### PR TITLE
Update Teckin RF-SR40-US

### DIFF
--- a/_templates/teckin_RF-SR40-US
+++ b/_templates/teckin_RF-SR40-US
@@ -3,7 +3,7 @@ date_added: 2020-02-13
 title: Teckin RF-SR40-US
 model: RF-SR40-US
 image: /assets/images/teckin_RF-SR40-US.jpg
-template: '{"NAME":"RF-SR40-US","GPIO":[0,0,0,0,57,56,0,0,21,17,0,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"RF-SR40-US","GPIO":[58,0,0,17,56,18,0,0,22,21,57,23,158],"FLAG":0,"BASE":18}'
 link: https://smile.amazon.com/dp/B07RFPSZLG
 link2: 
 mlink: 


### PR DESCRIPTION
Purchased a [Teckin RF-SR40-US](https://smile.amazon.com/dp/B07RFPSZLG) on March 11, 2020. Using the previous template, the device does not function properly (toggling relay 1 turns on the bottom receptacle, among other issues) and in fact the device resets Tasmota all the way back to soft AP mode (Tasmota-#### and WiFi config) as the GPIO13 pin (previously defined as Button1) performs a reset if pulled high for 40 seconds, which would happen any time you turn the top receptacle relay on (as GPIO13 is actually the top receptacle's relay).

I'm not sure if this was caused by undocumented manufacturing changes (the model number on the Amazon listing is identical to the device itself - `RF-SR40-US`) or if the previous template never worked (I'd like to think that not the case) but either way, the correct pinout for the device is as follows:
    - **GPIO0 - Led3i (58)** - USB port power status (middle green LED)
    - **GPIO3 - Button1 (17)** - Top button
    - **GPIO4 - Led1i (56)** - Top receptacle power status (top red LED)
    - **GPIO5 - Button2 (18)** - Bottom button
    - **GPIO12 - Relay2 (22)** - Bottom receptacle relay
    - **GPIO13 - Relay1 (21)** - Top receptacle relay
    - **GPIO14 - Led2i (57)** - Bottom receptacle power status (bottom red LED)
    - **GPIO15 - Relay3 (23)** - USB port relay
    - **GPIO16 - LedLinki (158)** - Otherwise unused; declared as **LedLinki (158)** so the LEDs are linked to their corresponding relays.