### PR TITLE
This relay has additional, external switch

### DIFF
--- a/_templates/geekcreit_10A
+++ b/_templates/geekcreit_10A
@@ -6,7 +6,7 @@ type: Relay
 standard: global
 link: https://www.banggood.com/Geekcreit-ESP8266-Development-Board-WIFI-Relay-Module-220V-10A-Relay-p-1436275.html
 image: https://img.staticbg.com/images/oaupload/banggood/images/AC/25/ea80f17f-2906-4ddd-8660-b2a177c7da92.jpg
-template: '{"NAME":"WeMos Relay","GPIO":[17,255,52,255,21,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"DIY ESP8266 Re","GPIO":[0,0,157,0,21,17,0,0,0,0,0,0,0],"FLAG":0,"BASE":18}' 
 link2: http://s.click.aliexpress.com/e/4PepjPYG
 
 ---


### PR DESCRIPTION
This relay has additional, external switch on GPIO4 and separate LED for relay state, so the blue led should indicate wifi status - not relay.