### PR TITLE
Update hugoai_awp02l-n

### DIFF
--- a/_templates/hugoai_awp02l-n
+++ b/_templates/hugoai_awp02l-n
@@ -11,3 +11,13 @@ link2:
 ---
 
 
+
+Title: AWP02L-N (FCCID:2ANJP-AWP02LN)
+Category: plug
+Standard: US
+Template: {"NAME":"AWP02L-N","GPIO":[58,0,56,0,0,0,0,0,0,17,0,21,0],"FLAG":1,"BASE":18}
+Link: https://www.amazon.com/HUGOAI-Outlet-Required-Control-Devices/dp/B07D9G92BF
+Image: https://images-na.ssl-images-amazon.com/images/I/51Rj-KwLo1L._AC_SL1500_.jpg
+
+
+

--- a/_templates/hugoai_awp02l-n
+++ b/_templates/hugoai_awp02l-n
@@ -1,23 +1,12 @@
 ---
 date_added: 2019-03-20
 title: AWP02L-N
+model: FCCID 2ANJP-AWP02LN
 category: plug
 type: Plug
 standard: us
 link: https://www.amazon.com/gp/product/B07LF768Y8
 image: https://images-na.ssl-images-amazon.com/images/I/41BNWkmtn2L._SL1001_.jpg
-template: '{"NAME":"AWP02L-N","GPIO":[57,0,56,0,0,0,0,0,0,17,0,21,0],"FLAG":1,"BASE":18}' 
-link2: 
+template: '{"NAME":"AWP02L-N","GPIO":[0,0,56,0,0,0,0,0,0,17,0,21,0],"FLAG":0,"BASE":18}' 
+link2: https://www.amazon.com/HUGOAI-Outlet-Required-Control-Devices/dp/B07D9G92BF
 ---
-
-
-
-Title: AWP02L-N (FCCID:2ANJP-AWP02LN)
-Category: plug
-Standard: US
-Template: {"NAME":"AWP02L-N","GPIO":[58,0,56,0,0,0,0,0,0,17,0,21,0],"FLAG":1,"BASE":18}
-Link: https://www.amazon.com/HUGOAI-Outlet-Required-Control-Devices/dp/B07D9G92BF
-Image: https://images-na.ssl-images-amazon.com/images/I/51Rj-KwLo1L._AC_SL1500_.jpg
-
-
-


### PR DESCRIPTION
Assuming that this is the same plug as the HugoAI version, I would recommend a slight change to the template.

At least on the HugoAi version, setting GPIO00 to LED2i (57) prevents the power LED from turning on when the plug is toggled on.  Setting GPIO00 to LED3i (58) instead, gives you both a power LED when toggled on and the MQTT heartbeat blink when there is no connection to the MQTT server (but only when the plug is in the off state).