### PR TITLE
Update Feit LEDR6/RGB

### DIFF
--- a/_templates/feit_electric-LEDR6_RGBW_AG
+++ b/_templates/feit_electric-LEDR6_RGBW_AG
@@ -3,7 +3,7 @@ date_added: 2020-04-14
 title: Feit Electric 6in. RGBW Recessed Downlight
 model: LEDR6/RGBW/AG
 image: /assets/images/feit_electric-LEDR6_RGBW_AG.jpg
-template: '{"NAME":"Feit LEDR6/RGB","GPIO":[0,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":48}' 
+template: '{"NAME":"Feit LEDR6/RGB","GPIO":[0,0,0,0,37,40,0,0,38,50,39,0,0],"FLAG":0,"BASE":48}' 
 link: https://www.amazon.com/Feit-Electric-LEDR6-RGBW-Multi-Color/dp/B07ZWTFLCF/
 link2: 
 mlink: https://www.feit.com/product/6-smart-alexa-google-recessed-downlight/

--- a/_templates/feit_electric-LEDR6_RGBW_AG
+++ b/_templates/feit_electric-LEDR6_RGBW_AG
@@ -1,9 +1,9 @@
 ---
 date_added: 2020-04-14
-title: Fiet Electric 6in. RGBW Recessed Downlight
+title: Feit Electric 6in. RGBW Recessed Downlight
 model: LEDR6/RGBW/AG
 image: /assets/images/feit_electric-LEDR6_RGBW_AG.jpg
-template: '{"NAME":"Fiet LEDR6/RGB","GPIO":[0,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":48}' 
+template: '{"NAME":"Feit LEDR6/RGB","GPIO":[0,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":48}' 
 link: https://www.amazon.com/Feit-Electric-LEDR6-RGBW-Multi-Color/dp/B07ZWTFLCF/
 link2: 
 mlink: https://www.feit.com/product/6-smart-alexa-google-recessed-downlight/


### PR DESCRIPTION
Fix misspelling of Feit

Color temperature for white was inverted. It is unclear whether this is due to how Tasmota handles lights based on the Xiaomi Philips module (https://github.com/arendst/Tasmota/issues/3055#issuecomment-613538451) or something particular to this light. In any case, inverting PWM5 causes color temperature for this light to function as expected.