### PR TITLE
Update gosund-SW2

### DIFF
--- a/_templates/gosund-SW2
+++ b/_templates/gosund-SW2
@@ -96,6 +96,7 @@ endif
 ;add first and second nibbles then to Tasmota dimming path
 f+=d
 =>dimmer %f%
+slider=f
 endif
 
 #scDim(dimval)


### PR DESCRIPTION
current dimmer value is correct if only set through MQTT, but is not remembered correctly when adjusting via the control pad.  Set the slider value after updating the dimmer value when changed with the touchpad for more consistent operation.