### PR TITLE
Update lohas-ZN011

### DIFF
--- a/_templates/lohas-ZN011
+++ b/_templates/lohas-ZN011
@@ -12,3 +12,9 @@ category: bulb
 type: RGBCCT
 standard: gu10
 ---
+
+If your device has been connected to the Tuya Smart app then you may need to configure it with an alternative template;
+
+```
+{"NAME":"LohasZN011-Tuya","GPIO":[0,0,0,0,0,0,0,0,0,143,0,144,0],"FLAG":0,"BASE":27}
+```

--- a/_templates/lohas-ZN011
+++ b/_templates/lohas-ZN011
@@ -5,7 +5,7 @@ model: LH-ZN01102U10-2
 image: /assets/images/lohas-ZN011.jpg
 template: '{"NAME":"LohasZN011","GPIO":[0,0,0,0,38,37,0,0,41,39,40,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.amazon.de/-/en/gp/product/B078XD699G/
-link2: 
+link2: https://www.amazon.co.uk/gp/product/B078XD699G/
 mlink: 
 flash: tuya-convert
 category: bulb
@@ -13,7 +13,7 @@ type: RGBCCT
 standard: gu10
 ---
 
-If your device has been connected to the Tuya Smart app then you may need to configure it with an alternative template;
+Some bulbs bought after April 2020 use this template:
 
 ```
 {"NAME":"LohasZN011-Tuya","GPIO":[0,0,0,0,0,0,0,0,0,143,0,144,0],"FLAG":0,"BASE":27}


### PR DESCRIPTION
I received 2 new ZN011 bulbs and 2 old ZN011 bulbs which had been connected to the Tuya Smartlife application.

The new bulbs worked with the template provided in the current documentation, but the bulbs which had been connected to Tuya did not. 

Thanks to help from @sfromis I was able to use some additional configuration to ensure the bulb was working. I can now use the full spectrum of RGB and brightness on the new and old bulbs. 