### PR TITLE
Update EU Lumary RGBCCT

### DIFF
--- a/_templates/lumary_led_strip
+++ b/_templates/lumary_led_strip
@@ -13,3 +13,5 @@ standard:
   - uk
   - de
 ---
+
+Newer versions of the controller in this set no longer contain an ESP-82** chip, instead containing a WR3E, which is not compatible with Tasmota.


### PR DESCRIPTION
I just bought one of these devices in France, which was shipped from Germany. The chip shows "WR3E" when opening the device.

This PR adds the warning of the US version to the EU version.