### PR TITLE
Update calex-429008

### DIFF
--- a/_templates/calex-429008
+++ b/_templates/calex-429008
@@ -9,7 +9,7 @@ link2:
 mlink: https://www.calex.nl/en/products/product/LEDKAAB35E14-5W-2200-4000KSMDSMART/
 flash: tuya-convert
 category: bulb
-type: RGBW
+type: RGBCCT
 standard: e14
 ---
 `SetOption37 30` or the R and G will be reversed


### PR DESCRIPTION
Is an RGB+CCT bulb. As of producer: 100+ RGB color options - CCT: 2200-4000K (white color)