### PR TITLE
Update Deta 4 Gang

### DIFF
--- a/_templates/deta_6904HA
+++ b/_templates/deta_6904HA
@@ -3,7 +3,7 @@ date_added: 2020-05-16
 title: Deta 4 Gang
 model: 6904HA
 image: /assets/images/deta_6904HA.jpg
-template: '{"NAME":"Deta 4G Switch","GPIO":[157,0,0,17,18,24,0,0,21,19,22,23,20],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"Deta 4G Switch","GPIO":[157,0,0,19,18,21,0,0,23,20,22,24,17],"FLAG":0,"BASE":18}' 
 link: https://www.bunnings.com.au/deta-smart-touch-activated-quad-gang-light-switch-with-grid-connect_p0161015
 link2: 
 mlink: 


### PR DESCRIPTION
The button order is clock-wise. With the status light is on the top, it starts from (1) bottom left, (2) top left, (3) top right, (4) bottom right. This also corresponds to the terminal labels on the mounting block.