### PR TITLE
[bauhn_ASPU-1019] Merge two relays into one

### DIFF
--- a/_templates/bauhn_ASPU-1019
+++ b/_templates/bauhn_ASPU-1019
@@ -6,16 +6,10 @@ type: Plug
 standard: au
 mlink: https://bauhn.com.au/wp-content/uploads/2020/02/ASPU-1019-Smart-Wall-Plug-UM-v8.pdf
 image: /assets/images/bauhn_ASPU-1019.jpg
-template: '{"NAME":"Buahn Smart Pl","GPIO":[0,0,0,0,21,22,0,0,0,56,17,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"Bauhn Smart Pl","GPIO":[0,0,0,0,21,21,0,0,0,56,17,0,0],"FLAG":0,"BASE":18}' 
 link2: 
 ---
 
-This device uses two relays, so use the following commands to setup a rule to trigger the second relay when the first is triggered
-
-```console
-rule1 on power1#state do power2 %value% endon
-rule1 1
-```
 
 
 


### PR DESCRIPTION
This device only has one outlet, and the previous settings created two relays, as a result, the MQTT RESULT contains POWER1 instead of POWER. There is no need to be able to control each relay independently. By setting both GPIO4 and GPIO5 to `relay1` it removes the need for the "power2 on boot hack" and makes the MQTT result cleaner. Therefore this will appear as a single relay device, without having to deal with POWER1 / POWER2.

Also fixed typo in the template name