### PR TITLE
Add Generic GU10 RGBCCT 5W 460lm

### DIFF
--- a/_templates/generic-gu10-rgbcct-5w
+++ b/_templates/generic-gu10-rgbcct-5w
@@ -1,0 +1,11 @@
+---
+date_added: 2020-05-27
+title: Generic GU10 RGBCCT 5W 460lm
+link: https://www.ebay.de/itm/5W-GU10-LED-Smart-WIFI-Birne-Glühbirne-RGBW-Dimmbar-für-Alexa-Google-Home-DE-DHL/124139389928
+image: https://i.ebayimg.com/images/g/HFgAAOSwdppeheGc/s-l1600.jpg
+template: '{"NAME":"RGBCCT GU10","GPIO":[0,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":18}'
+flash: tuya-convert
+category: bulb
+type: RGBCCT
+standard: gu10
+---


### PR DESCRIPTION
This PR adds a generic GU10 bulb with RGBCCT (warm and cold white). I cant find any branding in the ebay listing or on the product itself