### PR TITLE
Change picture URLs

### DIFF
--- a/_templates/powrui_AW-08
+++ b/_templates/powrui_AW-08
@@ -56,5 +56,5 @@ After you are satisfied all is well, cut or unsolder the wires.  Put the PCD bac
 The unit should go back together smoothly.
 
 ### Pictures
-![Serial Connections](https://github.com/blakadder/templates/blob/master/assets/images/pwrui-aw-08-serial1.jpg)
-![GPIO0 and capacitor](https://github.com/blakadder/templates/blob/master/assets/images/pwrui-aw-08-serial2.jpg)
+![Serial Connections](https://github.com/blakadder/templates/blob/master/assets/images/pwrui-aw-08-serial1.jpg&raw=1)
+![GPIO0 and capacitor](https://github.com/blakadder/templates/blob/master/assets/images/pwrui-aw-08-serial2.jpg&raw=1)


### PR DESCRIPTION
Change the picture URLs to fully qualified URLs and properly terminate the markdown with a closing paren.  @blakadder  - obviously with this change I am assuming that the file parser understands the absolute URL and the image markdown.  