### PR TITLE
Correct template for SH-LE27W

### DIFF
--- a/_templates/deltaco_SH-LE27W
+++ b/_templates/deltaco_SH-LE27W
@@ -6,7 +6,7 @@ category: bulb
 standard: e27
 link: https://www.webhallen.com/se/product/309664-Deltaco-Smart-Bulb-E27-White
 image: https://www.deltaco.se/sites/cdn/PublishingImages/Products/SH-LE27W.png?width=260
-template: '{"NAME":"SH-LE27W","GPIO":[0,0,0,0,0,140,0,0,38,0,37,142,141],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"SH-LE27W","GPIO":[0,0,0,0,0,0,0,0,38,0,37,0,0],"FLAG":0,"BASE":18}' 
 mlink: https://www.deltaco.se/produkter/deltaco/smart-home/belysning/SH-LE27W
 ---
 


### PR DESCRIPTION
The lighting controller is not needed, just the two PWM channels.