### PR TITLE
update to rules...

### DIFF
--- a/_templates/wisdom_ZY_ACU02
+++ b/_templates/wisdom_ZY_ACU02
@@ -11,18 +11,10 @@ link2: https://www.aliexpress.com/item/4000106855079.html
 ---
 
 Rule to toggle LED's with relays...    
-`Backlog ledmask 0x0000; seriallog 0; rule1 on power1#state do power3 %value% endon on power2#state do power4 %value% endon; rule1 1`
+`Backlog ledmask 0x0000; seriallog 0; setoption32 20; rule1 on power1#state do ledpower1 %value% endon on power2#state do ledpower2 %value% endon; rule1 1`
 
-Rule for Button to control both relays
+The functionality below is built into firmware 8.3.1>
 
 1 short press for relay1
 
-2 short presses for relay2...
-
-`Backlog ButtonTopic 0; SetOption1 1; SetOption11 1; SetOption32 20; Rule2 on button1#state=3 do delay endon on button1#state=2 do power2 toggle endon; Rule2 1`
-
-
-
-
-
-
+2 short presses for relay2

--- a/_templates/wisdom_ZY_ACU02
+++ b/_templates/wisdom_ZY_ACU02
@@ -13,7 +13,7 @@ link2: https://www.aliexpress.com/item/4000106855079.html
 Rule to toggle LED's with relays...    
 `Backlog ledmask 0x0000; seriallog 0; setoption32 20; rule1 on power1#state do ledpower1 %value% endon on power2#state do ledpower2 %value% endon; rule1 1`
 
-The functionality below is built into firmware 8.3.1>
+The Button functionality below is built into firmware 8.3.1>
 
 1 short press for relay1
 


### PR DESCRIPTION
Rule1 needed to change to match new GPIO assignments in PR528.
Rule2 is no longer necessary in firmware 8.3.1.