### PR TITLE
Update eco_plugs_CT-065W to include Status LED

### DIFF
--- a/_templates/eco_plugs_CT-065W
+++ b/_templates/eco_plugs_CT-065W
@@ -6,7 +6,7 @@ type: Plug
 standard: us
 link: https://www.homedepot.com/p/Grounded-Indoor-Wi-Fi-Adapter-2-Pack-CT-065W/206177754
 image: /assets/images/eco_plugs_CT-065W.jpg
-template: '{"NAME":"ECO/CT-065W","GPIO":[0,0,0,0,0,0,0,0,0,17,0,21,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"ECO/CT-065W","GPIO":[0,0,158,0,0,0,0,0,0,17,0,21,0],"FLAG":0,"BASE":18}' 
 link2: http://www.eco-plugs.net/en/products/show.php?id=9
 ---
 


### PR DESCRIPTION
The Red LED is tied to the relay (or so it appears), but the blue LED is a usable LED, and appears to be inverted.

I've added it to my devices on the template screen and propose this modification to the repository.

Thanks.