### PR TITLE
Blitzwolf BW-SS4 one-gang / two-gang

### DIFF
--- a/_templates/blitzwolf_BW-SS4
+++ b/_templates/blitzwolf_BW-SS4
@@ -1,11 +1,12 @@
 ---
 date_added: 2020-03-30
-title: BlitzWolf SS4 Two Gang
+title: BlitzWolf SS4
 model: BW-SS4
 image: /assets/images/blitzwolf_BW-SS4.jpg
-template: '{"NAME":"BlitzWolf SS4","GPIO":[0,0,0,0,56,21,0,0,22,17,0,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"BlitzWolf SS4 Two Gang","GPIO":[0,0,0,0,56,21,0,0,22,17,0,0,0],"FLAG":0,"BASE":18}'
+template-alt: '{"NAME":"BlitzWolf SS4 One Gang","GPIO":[0,0,0,0,56,21,0,0,0,17,0,0,0],"FLAG":0,"BASE":18}'
 link: https://www.aliexpress.com/item/4000340496577.html
-link2: 
+link2: https://www.banggood.com/BlitzWolf-BW-SS4-Basic-2200W-10A-12-Way-WIFI-DIY-Smart-Switch-Module-p-1593822.html
 mlink: https://www.blitzwolf.com/
 flash: tuya-convert
 category: relay


### PR DESCRIPTION
Blitzwolf BW-SS4 comes in "one gang" and "two gang" versions. 

Since everything else is the same, including the buy links, I have added the other one as an alternative template instead of a new device.