### PR TITLE
Set GPIO 12 to 47 to invert CCT range

### DIFF
--- a/_templates/mirabella_genio_I002742
+++ b/_templates/mirabella_genio_I002742
@@ -6,7 +6,7 @@ type: Light
 standard: au
 link: https://www.kmart.com.au/product/mirabella-genio-wi-fi-dimmable-9w-led-downlight/2754331
 image: https://www.kmart.com.au/wcsstore/Kmart/images/ncatalog/sz/7/42799337-1-sz.jpg
-template: '{"NAME":"GenioDLightCCT","GPIO":[0,0,0,0,0,0,0,0,38,0,37,0,0],"FLAG":0,"BASE":48}' 
+template: '{"NAME":"GenioDLightCCT","GPIO":[0,0,0,0,0,0,0,0,47,0,37,0,0],"FLAG":0,"BASE":48}' 
 link2:
 mlink: https://mirabellagenio.net.au/downlight-rgb%2Bcct
 ---


### PR DESCRIPTION
Current GPIO 12 value of 38 (PWM2) has the CCT scale inverted. Setting it to 47 (PWM2i) to correct the scale