### PR TITLE
Correct template for CCT light

### DIFF
--- a/_templates/connect_smarthome_CSH-E27WW10W
+++ b/_templates/connect_smarthome_CSH-E27WW10W
@@ -3,7 +3,7 @@ date_added: 2020-07-19
 title: Connect SmartHome 10W 900lm
 model: CSH-E27WW10W
 image: /assets/images/connect_smarthome_CSH-E27WW10W.jpg
-template: '{"NAME":"Connect CCT","GPIO":[0,0,0,0,0,37,0,0,0,38,0,0,0],"FLAG":0,"BASE":48}' 
+template: '{"NAME":"Connect CCT","GPIO":[0,0,0,0,0,37,0,0,0,38,0,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.harveynorman.com.au/connect-smart-10w-e27-white-led-light-bulb.html
 link2: 
 mlink: https://www.connectsmarthome.com.au/guides/lights/CSH%20User%20Manual%20-%20E27%20B22.pdf

--- a/_templates/connect_smarthome_CSH-E27WW10W
+++ b/_templates/connect_smarthome_CSH-E27WW10W
@@ -3,9 +3,9 @@ date_added: 2020-07-19
 title: Connect SmartHome 10W 900lm
 model: CSH-E27WW10W
 image: /assets/images/connect_smarthome_CSH-E27WW10W.jpg
-template: '{"NAME":"Connect CCT","GPIO":[0,0,0,0,0,37,0,0,0,38,0,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"CSH-E27WW10W","GPIO":[0,0,0,0,0,37,0,0,0,38,0,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.harveynorman.com.au/connect-smart-10w-e27-white-led-light-bulb.html
-link2: 
+link2: https://www.laserco.com.au/categories/smart-home/smart-lighting/LSH-E27WW10W-laser-10W-Smart-White-Bulb-E27
 mlink: https://www.connectsmarthome.com.au/guides/lights/CSH%20User%20Manual%20-%20E27%20B22.pdf
 flash: tuya-convert
 category: bulb


### PR DESCRIPTION
I had to change the template base from `48` to `18` get it working. This is based on the same device (different socket):
https://github.com/blakadder/templates/blob/master/_templates/CSH-B22WW10W

Also I didn't have to use the TuyaSmart app, I just flashed the firmware on the very first use so it started rapid-flashing as soon as I applied power.