### PR TITLE
Gosund LED Strip BT01-T-V2.2

### DIFF
--- a/_templates/gosund_led_strip
+++ b/_templates/gosund_led_strip
@@ -12,3 +12,6 @@ category: light
 type: LED Strip
 standard: global
 ---
+
+Other versions of the controller might use a different layout.
+Version BT01-T-V2.2 of the board uses GPIO5 for PWM2 (instead of GPIO15): '{"NAME":"Gosund LED Strip","GPIO":[17,0,0,0,0,38,0,0,37,39,0,0,0],"FLAG":3,"BASE":18}'


### PR DESCRIPTION
Added a note for Gosund LED Strip. Version BT01-T-V2.2 of the controller's board uses GPIO5 (instead of GPIO15) for PWM2.