### PR TITLE
Update sonoff_basic_R3

### DIFF
--- a/_templates/sonoff_basic_R3
+++ b/_templates/sonoff_basic_R3
@@ -7,7 +7,7 @@ type: Relay
 standard: global
 flash: sonoff-diy
 image: https://user-images.githubusercontent.com/5904370/67286319-7c2e4b00-f4d9-11e9-9c3d-993e5a8c6422.png
-template: '{"NAME":"Basic R3","GPIO":[17,255,0,255,255,0,0,0,21,56,0,0,255],"FLAG":0,"BASE":1}' 
+template: '{"NAME":"Basic R3","GPIO":[17,255,0,255,255,0,255,255,21,56,0,0,255],"FLAG":0,"BASE":1}' 
 link: https://www.itead.cc/sonoff-basicr3-wifi-diy-smart-switch.html
 link2: https://www.banggood.com/SONOFF-BASIC-R3-10A-2200W-Smart-ONOFF-WIFI-Wireless-Switch-Light-Timer-Support-DIY-Mode-APPLANVoice-Remote-Control-BASICR3-Works-With-Amazon-Alexa-Google-Home-Nest-Assistant-IFTTT-p-1451233.html
 link3: https://www.amazon.com/dp/B07S59CGQ1


### PR DESCRIPTION
Since Itead use ESD8265 on R3, GPIO 9 & 10 are available in the pads of the unpopulated Flash chip.
Changed GPIO 9 & 10 to User to made them visible on Configure -> Module