### PR TITLE
Fix Heyvalue HLT-331

### DIFF
--- a/_templates/heyvalue_HLT-331
+++ b/_templates/heyvalue_HLT-331
@@ -3,7 +3,7 @@ date_added: 2020-05-19
 title: Heyvalue 4AC+4USB
 model: HLT-331
 image: /assets/images/heyvalue_HLT-331.jpg
-template: '{"NAME":"Heyvalue HLT-331","GPIO":[56,0,57,0,25,22,0,0,24,9,23,21,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"Heyvalue HLT-331","GPIO":[57,0,158,56,32,17,0,0,30,31,29,0,25],"FLAG":0,"BASE":18}' 
 link: https://www.amazon.com/Protector-Appliances-Individual-Schedule-Required/dp/B076VRH9WP
 link2: 
 mlink: 


### PR DESCRIPTION
The given template did not work properly. 
Issues with old template
* Only 3 of the relays were controllable and they were not using inverted relays. 
* switch was not mapped to the correct GPIO and should have been mapped as a button. 
* One of the LEDs was not mapped at all