### PR TITLE
Update lsc_smart_connect_led_strip

### DIFF
--- a/_templates/lsc_smart_connect_led_strip
+++ b/_templates/lsc_smart_connect_led_strip
@@ -6,13 +6,18 @@ type: LED Strip
 standard: eu
 link: https://www.action.com/de-de/p/lsc-smart-connect-intelligenter-multicolor-led-strip-/
 image: https://www.action.com/globalassets/cmsarticleimages/79/81/2578634_8712879142775-111.png?preset=mediaSliderImageLarge
-template: '{"NAME":"LSC RGBW Strip","GPIO":[51,0,0,0,37,0,0,0,38,40,39,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"LSC RGBW Strip","GPIO":[51,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":18}'
 link2: 
 ---
 ## Warning
 
 As of July 2020 this device comes with a Tuya WB3S module which cannot be flashed with Tasmota.     
-That module is pin compatible with ESP-12 and can be replaced.
+That module is pin compatible with ESP-12 and can ordered via Ebay. Replace the modul with a hot air gun. All LEDs are usable R,G,B,CW,WW and you can dimm it.
+
+image: https://open-boat-projects.org/wp-content/uploads/2020/08/WB3S_ESP8266_kl.png
+
+image:https://open-boat-projects.org/wp-content/uploads/2020/08/LSC_RGBW_LED_Stripe_kl.png
+
 
 To use the build in IR Receiver connected to GPIO00 as IRrecv (if this cannot be selected under configuration use Tasmota-Sensors.bin) add the following rule via Command Line. 
 


### PR DESCRIPTION
Add an new configuration for newer LSC RGBW stripe (> 07/2020) and two pictures. Now are usable all LEDs include CW and WW LED.