### PR TITLE
add nz supplier links

### DIFF
--- a/_templates/arlec_ABL015HA
+++ b/_templates/arlec_ABL015HA
@@ -3,12 +3,12 @@ date_added: 2020-07-29
 title: Arlec Smart 10W LED Bunker
 model: ABL015HA
 image: /assets/images/arlec_ABL015HA.jpg
-template: '{"NAME":"DetaBulkhead","GPIO":[0,0,0,0,0,0,0,0,0,0,37,0,0],"FLAG":0,"BASE":18}' 
-link: https://www.bunnings.com.au/arlec-grid-connect-smart-10w-led-bunker-light_p0119822
-link2: 
 mlink: 
 flash: tuya-convert
 category: light
 type: Light
 standard: au
+template: '{"NAME":"DetaBulkhead","GPIO":[0,0,0,0,0,0,0,0,0,0,37,0,0],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.com.au/arlec-grid-connect-smart-10w-led-bunker-light_p0119822
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-led-bunker-light_p0119822
 ---

--- a/_templates/arlec_ABL204HA
+++ b/_templates/arlec_ABL204HA
@@ -3,12 +3,12 @@ date_added: 2020-06-05
 title: Arlec Smart Up & Down LED Wall 
 model: ABL204HA
 image: /assets/images/arlec_ABL204HA.jpg
-template: '{"NAME":"Arlec Up Down CCT","GPIO":[0,0,0,0,0,37,0,0,0,38,0,0,0],"FLAG":0,"BASE":18}' 
-link: https://www.bunnings.com.au/arlec-smart-up-and-down-led-wall-light-with-grid-connect_p0119823
-link2: 
 mlink: 
 flash: tuya-convert
 category: light
 type: Light
 standard: au
+template: '{"NAME":"Arlec Up Down CCT","GPIO":[0,0,0,0,0,37,0,0,0,38,0,0,0],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.com.au/arlec-smart-up-and-down-led-wall-light-with-grid-connect_p0119823
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-up-and-down-led-wall-light_p0119823
 ---

--- a/_templates/arlec_AEL10HA
+++ b/_templates/arlec_AEL10HA
@@ -3,12 +3,12 @@ date_added: 2020-05-13
 title: Arlec 10m Smart Extension Lead
 model: AEL10HA
 image: /assets/images/arlec_AEL10HA.jpg
-template: '{"NAME":"Arlec Ext Cord","GPIO":[0,17,0,0,0,0,0,0,0,56,21,0,0],"FLAG":0,"BASE":18}' 
-link: https://www.bunnings.com.au/arlec-10m-smart-extension-lead-with-grid-connect_p0098824
-link2: 
 mlink: 
 flash: tuya-convert
 category: plug
 type: Plug
 standard: au
+template: '{"NAME":"Arlec Ext Cord","GPIO":[0,17,0,0,0,0,0,0,0,56,21,0,0],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.com.au/arlec-10m-smart-extension-lead-with-grid-connect_p0098824
+link2: https://www.bunnings.co.nz/arlec-10m-grid-connect-smart-extension-lead_p0098824
 ---

--- a/_templates/arlec_ALD233HA
+++ b/_templates/arlec_ALD233HA
@@ -2,12 +2,13 @@
 date_added: 2019-11-07
 title: Arlec Smart 2m LED Colour Changing Strip Light
 model: ALD233HA
+image: https://2ecffd01e1ab3e9383f0-07db7b9624bbdf022e3b5395236d5cf8.ssl.cf4.rackcdn.com/Product-1600x1600/11307e19-efcd-4fee-a698-0b37c5b20843.jpg
+mlink:
 category: light
 type: LED Strip
 standard: au
-link: https://www.bunnings.com.au/arlec-2m-led-white-smart-colour-changing-strip-light-with-grid-connect_p0099707
-image: https://2ecffd01e1ab3e9383f0-07db7b9624bbdf022e3b5395236d5cf8.ssl.cf4.rackcdn.com/Product-1600x1600/11307e19-efcd-4fee-a698-0b37c5b20843.jpg
 template: '{"NAME":"Arlec ALD233AH","GPIO":[0,0,0,0,37,40,0,0,38,0,39,0,0],"FLAG":0,"BASE":18}' 
-link2: 
+link: https://www.bunnings.com.au/arlec-2m-led-white-smart-colour-changing-strip-light-with-grid-connect_p0099707
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-2m-led-white-colour-changing-strip-light_p0099707
 ---
 

--- a/_templates/arlec_ELGD11HA
+++ b/_templates/arlec_ELGD11HA
@@ -3,13 +3,13 @@ date_added: 2020-02-26
 title: Arlec Smart 40W 4000lm LED Batten 
 model: ELGD11HA
 image: /assets/images/arlec_ELGD11HA.jpg
-template: '{"NAME":"Arlec Batten","GPIO":[0,0,0,0,0,37,0,0,0,0,0,0,0],"FLAG":0,"BASE":18}' 
-link: https://www.bunnings.com.au/arlec-smart-40w-4000lm-led-batten-light-with-grid-connect_p0117511
-link2: 
 mlink: 
 flash: serial
 category: light
 type: Light
 standard: au
+template: '{"NAME":"Arlec Batten","GPIO":[0,0,0,0,0,37,0,0,0,0,0,0,0],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.com.au/arlec-smart-40w-4000lm-led-batten-light-with-grid-connect_p0117511
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-40w-led-batten-light_p0117511
 ---
 Recently purchased device had updated firmware and wouldn't tuya-convert. Was able to easily access the TYWE3L chip and flash successfully with solder method. Jig would work fine also.

--- a/_templates/arlec_FL220HA
+++ b/_templates/arlec_FL220HA
@@ -3,13 +3,13 @@ date_added: 2020-03-15
 title: Arlec Smart Portable Floodlight 10.5W
 model: FL220HA/GLD301HA
 image: /assets/images/arlec_FL220HA.jpg
-template: '{"NAME":"Arlec GLD301HA","GPIO":[0,0,0,0,0,37,0,0,0,0,0,0,0],"FLAG":0,"BASE":18}' 
-link: https://www.bunnings.com.au/arlec-portable-floodlight-with-10-5w-grid-connect-smart-globe_p0117297
-link2: 
 mlink: 
 flash: tuya-convert
 category: light
 type: Light
 standard: au
+template: '{"NAME":"Arlec GLD301HA","GPIO":[0,0,0,0,0,37,0,0,0,0,0,0,0],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.com.au/arlec-portable-floodlight-with-10-5w-grid-connect-smart-globe_p0117297
+link2: https://www.bunnings.co.nz/arlec-grid-connect-portable-floodlight-with-10-5w-smart-globe_p0117297
 ---
 This the bulb in portable floodlight. Fixture is passive.

--- a/_templates/arlec_GLD060HA
+++ b/_templates/arlec_GLD060HA
@@ -3,12 +3,12 @@ date_added: 2020-03-17
 title: Arlec Smart 4W 380lm Candle
 model: GLD060HA
 image: /assets/images/arlec_GLD060HA.jpg
-template: '{"NAME":"Arlec Bulb 4W","GPIO":[0,0,0,0,0,0,0,0,0,0,37,0,0],"FLAG":0,"BASE":18}' 
-link: https://www.bunnings.com.au/arlec-smart-4w-380lm-warm-white-ses-candle-globe-with-grid-connect_p0111507
-link2: 
 mlink: 
 flash: tuya-convert
 category: bulb
 type: Dimmable
 standard: e14
+template: '{"NAME":"Arlec Bulb 4W","GPIO":[0,0,0,0,0,0,0,0,0,0,37,0,0],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.com.au/arlec-smart-4w-380lm-warm-white-ses-candle-globe-with-grid-connect_p0111507
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-4w-380lm-warm-white-ses-candle-globe_p0111507
 ---

--- a/_templates/arlec_GLD110HA
+++ b/_templates/arlec_GLD110HA
@@ -3,12 +3,12 @@ date_added: 2020-04-18
 title: Arlec Smart 9.5W 806lm
 model: GLD110HA
 image: /assets/images/arlec_GLD110HA.jpg
-template: '{"NAME":"Arlec GLD110HA","GPIO":[0,0,0,0,0,37,0,0,0,38,0,0,0],"FLAG":0,"BASE":48}' 
-link: https://www.bunnings.com.au/arlec-smart-9-5w-806lm-cct-bc-globe-with-grid-connect_p0111502
-link2: 
 mlink: 
 flash: tuya-convert
 category: bulb
 type: CCT
 standard: b22
+template: '{"NAME":"Arlec GLD110HA","GPIO":[0,0,0,0,0,37,0,0,0,38,0,0,0],"FLAG":0,"BASE":48}' 
+link: https://www.bunnings.com.au/arlec-smart-9-5w-806lm-cct-bc-globe-with-grid-connect_p0111502
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-9-5w-806lm-cct-bc-globe_p0111502
 ---

--- a/_templates/arlec_GLD112HA
+++ b/_templates/arlec_GLD112HA
@@ -2,13 +2,14 @@
 date_added: 2019-10-05
 title: Arlec Smart 9.5W 806lm
 model: GLD112HA
+image: https://2ecffd01e1ab3e9383f0-07db7b9624bbdf022e3b5395236d5cf8.ssl.cf4.rackcdn.com/Product-1600x1600/ded8c866-2599-4426-b6ff-3bb6ca3f643e.jpg
+mlink:
 type: CCT
 category: bulb
 standard: e27
 link: https://www.bunnings.com.au/arlec-smart-9-5w-806lm-cct-es-globe-with-grid-connect_p0111503
-image: https://2ecffd01e1ab3e9383f0-07db7b9624bbdf022e3b5395236d5cf8.ssl.cf4.rackcdn.com/Product-1600x1600/ded8c866-2599-4426-b6ff-3bb6ca3f643e.jpg
 template: '{"NAME":"Arlec CCT","GPIO":[0,0,0,0,0,37,0,0,0,38,0,0,0],"FLAG":0,"BASE":48}' 
-link2: 
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-9-5w-806lm-cct-es-globe_p0119820
 ---
 
 The bulb has hardware Gamma Correction included, you need to configure `LedTable 0` 

--- a/_templates/arlec_GLD120HA
+++ b/_templates/arlec_GLD120HA
@@ -3,12 +3,12 @@ date_added: 2020-04-24
 title: Arlec Smart 9.5W 806lm 
 model: GLD120HA
 image: /assets/images/arlec_GLD120HA.jpg
-template: '{"NAME":"Arlec RGBWW","GPIO":[0,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":18}' 
-link: https://www.bunnings.com.au/arlec-smart-9w-806lm-rgb-cct-bc-globe-with-grid-connect_p0111500
-link2: 
 mlink: 
 flash: tuya-convert
 category: bulb
 type: RGBCCT
 standard: b22
+template: '{"NAME":"Arlec RGBWW","GPIO":[0,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.com.au/arlec-smart-9w-806lm-rgb-cct-bc-globe-with-grid-connect_p0111500
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-9w-806lm-rgb-cct-bc-globe_p0111500
 ---

--- a/_templates/arlec_GLD122HA
+++ b/_templates/arlec_GLD122HA
@@ -2,11 +2,12 @@
 date_added: 2019-10-23
 title: Arlec Smart 9.5W 806lm
 model: GLD122HA
+image: /assets/images/arlec_GLD122HA.jpg
+mlink:
 type: RGBCCT
 category: bulb
 standard: e27
-link: https://www.bunnings.com.au/arlec-smart-9-5w-806lm-rgb-cct-es-globe-with-grid-connect_p0111501
-image: /assets/images/arlec_GLD122HA.jpg
 template: '{"NAME":"Arlec RGBWW","GPIO":[0,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":18}' 
-link2: 
+link: https://www.bunnings.com.au/arlec-smart-9-5w-806lm-rgb-cct-es-globe-with-grid-connect_p0111501
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-9-5w-806lm-rgb-cct-es-globe_p0111501
 ---

--- a/_templates/arlec_GLD302HA
+++ b/_templates/arlec_GLD302HA
@@ -3,12 +3,12 @@ date_added: 2020-03-15
 title: Arlec Smart 1350lm PAR38
 model: GLD302HA
 image: /assets/images/arlec_GLD302HA.jpg
-template: '{"NAME":"Arlec GLD302HA","GPIO":[0,0,0,0,0,0,0,0,38,0,37,0,0],"FLAG":0,"BASE":18}' 
-link: https://www.bunnings.com.au/arlec-smart-1350lm-cct-par38-es-globe-with-grid-connect_p0111510
-link2: 
 mlink: 
 flash: tuya-convert
 category: bulb
 type: CCT
 standard: e27
+template: '{"NAME":"Arlec GLD302HA","GPIO":[0,0,0,0,0,0,0,0,38,0,37,0,0],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.com.au/arlec-smart-1350lm-cct-par38-es-globe-with-grid-connect_p0111510
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-1350lm-cct-par38-es-globe_p0111510
 ---

--- a/_templates/arlec_MAL300H
+++ b/_templates/arlec_MAL300H
@@ -5,7 +5,7 @@ model: MAL300HA
 image: /assets/images/arlec_MAL300H.jpg
 template: '{"NAME":"Arlec MAL300HA","GPIO":[0,0,0,0,21,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.bunnings.com.au/arlec-smart-20w-security-light-with-movement-activated-sensor-grid-connect_p0117296
-link2: 
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-20w-security-light-with-movement-activated-sensor_p0117296
 mlink: 
 flash: tuya-convert
 category: light

--- a/_templates/arlec_PB88UHA
+++ b/_templates/arlec_PB88UHA
@@ -1,14 +1,15 @@
 ---
 date_added: 2019-10-29
 title: Arlec Smart PB88UHA
+image: https://2ecffd01e1ab3e9383f0-07db7b9624bbdf022e3b5395236d5cf8.ssl.cf4.rackcdn.com/Product-1600x1600/b6609933-ba09-4320-b8f9-ec95db6b7575.jpg
+mlink:
 category: plug
 type: Power Strip
-standard: au
-link: https://www.bunnings.com.au/arlec-4-outlet-smart-powerboard-with-usb-charger-and-grid-connect_p0074829
-image: https://2ecffd01e1ab3e9383f0-07db7b9624bbdf022e3b5395236d5cf8.ssl.cf4.rackcdn.com/Product-1600x1600/b6609933-ba09-4320-b8f9-ec95db6b7575.jpg
-template: '{"NAME":"Arlec PB88UHA","GPIO":[0,56,0,17,22,21,0,0,24,23,0,0,0],"FLAG":15,"BASE":18}'
-link2: 
 flash: tuya-convert
+standard: au
+template: '{"NAME":"Arlec PB88UHA","GPIO":[0,56,0,17,22,21,0,0,24,23,0,0,0],"FLAG":15,"BASE":18}'
+link: https://www.bunnings.com.au/arlec-4-outlet-smart-powerboard-with-usb-charger-and-grid-connect_p0074829
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-4-outlet-powerboard-with-usb-charger_p0074829
 ---
 
 

--- a/_templates/arlec_PB89HA
+++ b/_templates/arlec_PB89HA
@@ -1,12 +1,12 @@
 ---
 date_added: 2019-11-12
 title: Arlec Smart PB89HA
+image: https://2ecffd01e1ab3e9383f0-07db7b9624bbdf022e3b5395236d5cf8.ssl.cf4.rackcdn.com/Product-800x800/68e4b1c6-460c-420c-a5d8-53eef03be921.jpg
 category: plug
 type: Power Strip
 standard: au
-link: https://www.bunnings.com.au/arlec-5-outlet-smart-powerboard-with-grid-connect_p0074830
-image: https://2ecffd01e1ab3e9383f0-07db7b9624bbdf022e3b5395236d5cf8.ssl.cf4.rackcdn.com/Product-800x800/68e4b1c6-460c-420c-a5d8-53eef03be921.jpg
 template: '{"NAME":"Arlec PB89HA","GPIO":[0,56,0,17,22,21,0,0,24,23,0,0,0],"FLAG":0,"BASE":18}' 
-link2: 
+link: https://www.bunnings.com.au/arlec-5-outlet-smart-powerboard-with-grid-connect_p0074830
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-5-outlet-powerboard_p0074830
 ---
 Power button LED will light up when any of the power switches are turned on   

--- a/_templates/arlec_PC189HA
+++ b/_templates/arlec_PC189HA
@@ -1,13 +1,14 @@
 ---
 date_added: 2019-09-24
 title: Arlec Smart PC189HA
+image: https://2ecffd01e1ab3e9383f0-07db7b9624bbdf022e3b5395236d5cf8.ssl.cf4.rackcdn.com/Product-1600x1600/3e7fc9c0-4fdf-4058-ace5-c5432beedea4.jpg
+mlink:
 category: plug
 type: Plug
 standard: au
-link: https://www.bunnings.com.au/arlec-smart-plug-in-socket-with-grid-connect_p0087513
-image: https://2ecffd01e1ab3e9383f0-07db7b9624bbdf022e3b5395236d5cf8.ssl.cf4.rackcdn.com/Product-1600x1600/3e7fc9c0-4fdf-4058-ace5-c5432beedea4.jpg
 template: '{"NAME":"Arlec Single","GPIO":[0,0,0,0,57,0,0,0,21,0,90,0,0],"FLAG":0,"BASE":18}' 
-link2: 
+link: https://www.bunnings.com.au/arlec-smart-plug-in-socket-with-grid-connect_p0087513
+Link2: 
 ---
 
 Use Tuya Convert 2. This configuration will give you a Blue LED on the switch when on, nothing when off.

--- a/_templates/arlec_PC190HA
+++ b/_templates/arlec_PC190HA
@@ -1,13 +1,13 @@
 ---
 date_added: 2020-01-03
 title: Arlec Smart PC190HA
-link: https://www.bunnings.com.au/arlec-smart-plug-in-socket-with-grid-connect_p0135440
 image: https://media.bunnings.com.au/Product-800x800/703ac61b-deb3-41b0-8848-adf928fc0521.jpg
-template: '{"NAME":"Arlec-PC190HA","GPIO":[0,0,0,0,56,0,0,0,21,158,17,0,0],"FLAG":0,"BASE":18}' 
-link2: 
 mlink: 
 flash: tuya-convert
 category: plug
 type: Plug
 standard: au
+template: '{"NAME":"Arlec-PC190HA","GPIO":[0,0,0,0,56,0,0,0,21,158,17,0,0],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.com.au/arlec-smart-plug-in-socket-with-grid-connect_p0135440
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-plug-in-socket_p0135440
 ---

--- a/_templates/arlec_PC389HA
+++ b/_templates/arlec_PC389HA
@@ -3,13 +3,13 @@ date_added: 2020-05-03
 title: Arlec Smart 2.1A USB Charger
 model: PC389HA
 image: /assets/images/arlec_PC389HA.jpg
-template: '{"NAME":"Arlec Single","GPIO":[0,0,0,0,57,0,0,0,21,0,90,0,0],"FLAG":0,"BASE":18}' 
-link: https://www.bunnings.com.au/arlec-smart-plug-in-socket-with-2-1a-usb-charger-and-grid-connect_p0135441
-link2: 
 mlink: http://www.arlec.com.au/
 flash: tuya-convert
 category: plug
 type: Plug
 standard: au
+template: '{"NAME":"Arlec Single","GPIO":[0,0,0,0,57,0,0,0,21,0,90,0,0],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.com.au/arlec-smart-plug-in-socket-with-2-1a-usb-charger-and-grid-connect_p0135441
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-plug-in-socket-with-2-1a-usb-charger_p0135441
 ---
 Use Tuya Convert 2. This configuration will give you a Blue LED on the switch when on, nothing when off.

--- a/_templates/arlec_PC399HA
+++ b/_templates/arlec_PC399HA
@@ -3,14 +3,14 @@ date_added: 2020-04-11
 title: Arlec Smart PC399HA Plug
 model: PC399HA
 image: /assets/images/arlec_PC399HA.jpg
-template: '{"NAME":"PC399HA","GPIO":[0,0,0,17,134,132,0,0,131,158,21,0,0],"FLAG":0,"BASE":52}' 
-link: https://www.bunnings.com.au/arlec-smart-plug-in-socket-with-energy-aeter-and-grid-connect_p0135442
-link2: 
 mlink: 
 flash: serial
 category: plug
 type: Plug
 standard: au
+template: '{"NAME":"PC399HA","GPIO":[0,0,0,17,134,132,0,0,131,158,21,0,0],"FLAG":0,"BASE":52}' 
+link: https://www.bunnings.com.au/arlec-smart-plug-in-socket-with-energy-aeter-and-grid-connect_p0135442
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-plug-in-socket-with-energy-meter_p0135442
 ---
 Device is running 1.1.4 of Tuya FW, so not yet working with tuya-convert (11/04/2020). 
 

--- a/_templates/arlec_SGS01HA
+++ b/_templates/arlec_SGS01HA
@@ -3,14 +3,14 @@ date_added: 2020-06-17
 title: Arlec Smart Home Hub 
 model: SGS01HA
 image: /assets/images/arlec_SGS01HA.jpg
-template: '{"NAME":"Arlec Hub","GPIO":[0,107,0,108,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":54}' 
-link: https://www.bunnings.com.au/arlec-grid-connect-smart-home-hub_p0148571
-link2: 
 mlink: 
 flash: serial
 category: misc
 type: Bluetooth Bridge
 standard: au
+template: '{"NAME":"Arlec Hub","GPIO":[0,107,0,108,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":54}' 
+link: https://www.bunnings.com.au/arlec-grid-connect-smart-home-hub_p0148571
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-home-hub_p0148571
 ---
 1. Initially pair the hub and all sensors using the Tuya app
 

--- a/_templates/arlec_YEL20HA
+++ b/_templates/arlec_YEL20HA
@@ -3,13 +3,13 @@ date_added: 2020-05-22
 title: Arlec Heavy Duty 20m Extension Lead
 model: YEL20HA
 image: /assets/images/arlec_YEL20HA.jpg
-template: '{"NAME":"Arlec Ext Cord","GPIO":[0,17,0,0,0,0,0,0,0,56,21,0,0],"FLAG":0,"BASE":18}' 
-link: https://www.bunnings.com.au/arlec-20m-smart-extra-heavy-duty-extension-lead-with-grid-connect_p0098825
-link2: 
 mlink: 
 flash: tuya-convert
 category: plug
 type: Plug
 standard: au
+template: '{"NAME":"Arlec Ext Cord","GPIO":[0,17,0,0,0,0,0,0,0,56,21,0,0],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.com.au/arlec-20m-smart-extra-heavy-duty-extension-lead-with-grid-connect_p0098825
+link2: https://www.bunnings.co.nz/arlec-20m-grid-connect-smart-extra-heavy-duty-extension-lead_p0098825
 ---
 Converted with Tuya Convert 2.0 

--- a/_templates/arlec_twin_PC288HA
+++ b/_templates/arlec_twin_PC288HA
@@ -1,13 +1,15 @@
 ---
 date_added: 2019-09-28
 title: Arlec Twin PC288HA
+image: https://2ecffd01e1ab3e9383f0-07db7b9624bbdf022e3b5395236d5cf8.ssl.cf4.rackcdn.com/Product-1600x1600/8bab35c2-df31-4ca4-b33f-adc92e36d697.jpg
+mlink: 
 category: plug
 type: Plug
 standard: au
-link: https://www.bunnings.com.au/arlec-grid-connect-smart-plug-in-twin-socket_p0161001
-image: https://2ecffd01e1ab3e9383f0-07db7b9624bbdf022e3b5395236d5cf8.ssl.cf4.rackcdn.com/Product-1600x1600/8bab35c2-df31-4ca4-b33f-adc92e36d697.jpg
+flash: tuya-convert
 template: '{"NAME":"Arlec Twin","GPIO":[0,17,0,22,0,0,0,0,0,56,21,0,0],"FLAG":0,"BASE":18}' 
-link2: 
+link: https://www.bunnings.com.au/arlec-grid-connect-smart-plug-in-twin-socket_p0161001
+link2: https://www.bunnings.co.nz/arlec-grid-connect-smart-plug-in-twin-socket_p0161001
 ---
 
 Arlec Grid Twin Plug, available from Bunnings in Aus.

--- a/_templates/brilliantsmart-2069105
+++ b/_templates/brilliantsmart-2069105
@@ -1,13 +1,13 @@
 ---
 date_added: 2019-12-30
 title: BrilliantSmart 20691 Powerboard with USB Chargers
-link: https://www.amazon.com.au/Brilliant-Smart-WiFi-Powerboard-Chargers/dp/B07YXC7BRT
 image: https://www.brilliantsmart.com.au/wp-content/uploads/2019/03/20691-05.jpg
-template: '{"NAME":"B_WiFi-4","GPIO":[56,0,0,57,29,17,0,0,31,30,32,0,25],"FLAG":1,"BASE":18}' 
-link2: 
 mlink: https://www.brilliantsmart.com.au/smart-products/electrical/smart-powerboard/
 flash: tuya-convert
 category: plug
 type: Power Strip
 standard: au
+template: '{"NAME":"B_WiFi-4","GPIO":[56,0,0,57,29,17,0,0,31,30,32,0,25],"FLAG":1,"BASE":18}' 
+link: https://www.amazon.com.au/Brilliant-Smart-WiFi-Powerboard-Chargers/dp/B07YXC7BRT
+link2: https://www.pbtech.co.nz/product/SURBRS0001/
 ---

--- a/_templates/brilliantsmart_20676
+++ b/_templates/brilliantsmart_20676
@@ -11,8 +11,7 @@ type: Plug
 standard: au
 template: '{"NAME":"Brilliant","GPIO":[0,0,0,0,0,21,0,0,0,52,90,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.amazon.com.au/Brilliant-Smart-WiFi-Plug-Charger/dp/B07YXCN6DC
-link2: https://www.lightingillusions.com.au/shop/smart-home/brilliant-smart-wifi-plug-with-usb-charging-20676-05-33958?gclid=Cj0KCQiA04XxBRD5ARIsAGFygj9dvEPFYeo-JG4ohqe1XO9A2j4NzYF7Ht_jfhg5PXcqeb28rxU1j5AaAqRVEALw_wcB
 link3: https://www.officeworks.com.au/shop/officeworks/p/brilliant-lighting-smart-wifi-plug-with-usb-bl2067605
 Link4: https://www.bunnings.co.nz/brilliant-smart-wifi-plug-and-usb-charger_p0091644
-Link5: https://www.pbtech.co.nz/product/ADPBRS0002
+Link2: https://www.pbtech.co.nz/product/ADPBRS0002
 ---

--- a/_templates/brilliantsmart_20676
+++ b/_templates/brilliantsmart_20676
@@ -3,14 +3,16 @@ date_added: 2020-01-17
 title: BrilliantSmart 20676 USB Charger
 model: 20676/05
 image: https://www.brilliantsmart.com.au/wp-content/uploads/2018/12/Brilliant_Smart_WiFi_Plug_Rotating_callouts.gif
-template: '{"NAME":"Brilliant","GPIO":[0,0,0,0,0,21,0,0,0,52,90,0,0],"FLAG":0,"BASE":18}' 
-link: https://www.amazon.com.au/Brilliant-Smart-WiFi-Plug-Charger/dp/B07YXCN6DC
-link2: https://www.lightingillusions.com.au/shop/smart-home/brilliant-smart-wifi-plug-with-usb-charging-20676-05-33958?gclid=Cj0KCQiA04XxBRD5ARIsAGFygj9dvEPFYeo-JG4ohqe1XO9A2j4NzYF7Ht_jfhg5PXcqeb28rxU1j5AaAqRVEALw_wcB
-link3: https://www.officeworks.com.au/shop/officeworks/p/brilliant-lighting-smart-wifi-plug-with-usb-bl2067605
 mlink: https://www.brilliantsmart.com.au/smart-products/electrical/wifi-plug-with-usb-charger/
 flash: serial
 flash2: tuya-convert
 category: plug
 type: Plug
 standard: au
+template: '{"NAME":"Brilliant","GPIO":[0,0,0,0,0,21,0,0,0,52,90,0,0],"FLAG":0,"BASE":18}' 
+link: https://www.amazon.com.au/Brilliant-Smart-WiFi-Plug-Charger/dp/B07YXCN6DC
+link2: https://www.lightingillusions.com.au/shop/smart-home/brilliant-smart-wifi-plug-with-usb-charging-20676-05-33958?gclid=Cj0KCQiA04XxBRD5ARIsAGFygj9dvEPFYeo-JG4ohqe1XO9A2j4NzYF7Ht_jfhg5PXcqeb28rxU1j5AaAqRVEALw_wcB
+link3: https://www.officeworks.com.au/shop/officeworks/p/brilliant-lighting-smart-wifi-plug-with-usb-bl2067605
+Link4: https://www.bunnings.co.nz/brilliant-smart-wifi-plug-and-usb-charger_p0091644
+Link5: https://www.pbtech.co.nz/product/ADPBRS0002
 ---

--- a/_templates/brilliantsmart_20698
+++ b/_templates/brilliantsmart_20698
@@ -3,12 +3,13 @@ date_added: 2020-01-20
 title: BrilliantSmart 20698 9W 800lm 
 model: 20698/05
 image: https://www.brilliantsmart.com.au/wp-content/uploads/2019/03/20698-1.jpg
+mlink: https://www.brilliantsmart.com.au/smart-products/lighting/smart-globe-rgb/
+type: RGBW
+category: bulb
+standard: e27
+flash: tuya-convert
 template: '{"NAME":"Brilliant20698","GPIO":[0,0,0,0,141,140,0,0,37,142,0,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.amazon.com.au/Brilliant-Smart-WiFi-Light-Bulb/dp/B07YXBHRXP
 link2: https://www.jdlighting.com.au/brilliant-smart-colour-9w-e27-led-rgb-white-light-globe.html
-mlink: https://www.brilliantsmart.com.au/smart-products/lighting/smart-globe-rgb/
-flash: tuya-convert
-category: bulb
-type: RGBW
-standard: e27
+Link3: https://www.pbtech.co.nz/product/BULBRS0002
 ---

--- a/_templates/brilliantsmart_20699
+++ b/_templates/brilliantsmart_20699
@@ -2,15 +2,15 @@
 date_added: 2019-11-18
 title: BrilliantSmart 20699 9W 800lm 
 model: 20699/05
+image: https://www.brilliantsmart.com.au/wp-content/uploads/2019/03/20699-1.jpg
+mlink: https://www.brilliantsmart.com.au/smart-products/lighting/smart-globe-rgb/
 type: RGBW 
 category: bulb
 standard: b22
 flash: tuya-convert
-link: https://www.amazon.com.au/Brilliant-Smart-Colour-White-Globe/dp/B083139KLX
-mlink: https://www.brilliantsmart.com.au/smart-products/lighting/smart-globe-rgb/
-image: https://www.brilliantsmart.com.au/wp-content/uploads/2019/03/20699-1.jpg
 template: '{"NAME":"Brilliant20699","GPIO":[0,0,0,0,141,140,0,0,37,142,0,0,0],"FLAG":0,"BASE":18}' 
-link2: 
+link: https://www.amazon.com.au/Brilliant-Smart-Colour-White-Globe/dp/B083139KLX
+link2: https://www.pbtech.co.nz/product/BULBRS0001/
 ---
 White LED:   
 PWM on GPIO12

--- a/_templates/deta_6000HA
+++ b/_templates/deta_6000HA
@@ -3,13 +3,13 @@ date_added: 2020-01-30
 title: Deta 6000HA Smart Inline Switch
 model: 9311644094623
 image: https://user-images.githubusercontent.com/5904370/73432143-659e5800-4342-11ea-9a88-3d4334c151b2.png
-template: '{"NAME":"DETA-6000HA","GPIO":[0,17,0,0,0,0,0,0,0,56,21,0,0],"FLAG":0,"BASE":18}' 
-link: https://www.bunnings.co.nz/deta-smart-inline-switch-with-grid-connect_p0098816
-link2: 
 mlink: 
 flash: tuya-convert
 category: relay
 type: Relay
 standard: au
+template: '{"NAME":"DETA-6000HA","GPIO":[0,17,0,0,0,0,0,0,0,56,21,0,0],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.co.nz/deta-smart-inline-switch-with-grid-connect_p0098816
+link2: https://www.bunnings.co.nz/deta-grid-connect-smart-inline-switch_p0098816
 ---
 ![](https://user-images.githubusercontent.com/5904370/73432174-777ffb00-4342-11ea-982e-31b3a1413551.png)

--- a/_templates/deta_6210HA
+++ b/_templates/deta_6210HA
@@ -3,13 +3,13 @@ date_added: 2020-03-16
 title: DETA 62120HA Smart Plug Base
 model: 6210HA
 image: /assets/images/deta_6210HA.jpg
-template: '{"NAME":"DetaPlugBase","GPIO":[0,17,0,0,0,0,0,0,0,56,21,0,0],"FLAG":0,"BASE":18}' 
-link: https://www.bunnings.com.au/deta-smart-plug-base-with-grid-connect_p0098817
-link2: 
 mlink: 
 flash: tuya-convert
 category: plug
 type: Plug
 standard: au
+template: '{"NAME":"DetaPlugBase","GPIO":[0,17,0,0,0,0,0,0,0,56,21,0,0],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.com.au/deta-smart-plug-base-with-grid-connect_p0098817
+link2: https://www.bunnings.co.nz/deta-grid-connect-smart-plug-base_p0098817
 ---
 Smart 413 Plug, Australian approved and available locally.

--- a/_templates/deta_6903HA
+++ b/_templates/deta_6903HA
@@ -3,13 +3,13 @@ date_added: 2020-05-18
 title: Deta 3 Gang
 model: 6903HA
 image: /assets/images/deta_6903HA.jpg
-template: '{"NAME":"DETA 3G Switch","GPIO":[157,0,0,92,91,21,0,0,23,0,22,0,90],"FLAG":0,"BASE":18}' 
-link: https://www.bunnings.com.au/deta-smart-touch-activated-triple-gang-light-switch-with-grid-connect_p0161014
-link2: 
 mlink: 
 flash: serial
 category: switch
 type: Switch
 standard: au
+template: '{"NAME":"DETA 3G Switch","GPIO":[157,0,0,92,91,21,0,0,23,0,22,0,90],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.com.au/deta-smart-touch-activated-triple-gang-light-switch-with-grid-connect_p0161014
+link2: https://www.bunnings.co.nz/deta-grid-connect-smart-triple-gang-touch-light-switch_p0161014
 ---
 Comes with the new Tuya protocol, and as of May 18 it can't be flashed OTA.

--- a/_templates/deta_6904HA
+++ b/_templates/deta_6904HA
@@ -3,12 +3,12 @@ date_added: 2020-05-16
 title: Deta 4 Gang
 model: 6904HA
 image: /assets/images/deta_6904HA.jpg
-template: '{"NAME":"Deta 4G Switch","GPIO":[157,0,0,19,18,21,0,0,23,20,22,24,17],"FLAG":0,"BASE":18}' 
-link: https://www.bunnings.com.au/deta-smart-touch-activated-quad-gang-light-switch-with-grid-connect_p0161015
-link2: 
 mlink: 
 flash: serial
 category: switch
 type: Switch
 standard: au
+template: '{"NAME":"Deta 4G Switch","GPIO":[157,0,0,19,18,21,0,0,23,20,22,24,17],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.com.au/deta-smart-touch-activated-quad-gang-light-switch-with-grid-connect_p0161015
+link2: https://www.bunnings.co.nz/deta-grid-connect-smart-quad-gang-touch-light-switch_p0161015
 ---

--- a/_templates/deta_6912HA
+++ b/_templates/deta_6912HA
@@ -2,13 +2,13 @@
 date_added: 2019-10-16
 title: Deta 2 Gang
 model: 6912HA
+image: https://2ecffd01e1ab3e9383f0-07db7b9624bbdf022e3b5395236d5cf8.ssl.cf4.rackcdn.com/Product-1600x1600/ee76781a-1398-4a77-87ef-3091c1de7d45.jpg
 category: switch
 type: Switch
 standard: au
-link: https://www.bunnings.com.au/deta-smart-double-gang-light-switch-touch-activated-with-grid-connect_p0098812
-image: https://2ecffd01e1ab3e9383f0-07db7b9624bbdf022e3b5395236d5cf8.ssl.cf4.rackcdn.com/Product-1600x1600/ee76781a-1398-4a77-87ef-3091c1de7d45.jpg
 template: '{"NAME":"DETA 2G Switch","GPIO":[0,0,0,0,157,0,0,0,91,21,22,0,90],"FLAG":0,"BASE":18}' 
-link2: 
+link: https://www.bunnings.com.au/deta-smart-double-gang-light-switch-touch-activated-with-grid-connect_p0098812
+link2: https://www.bunnings.co.nz/deta-grid-connect-smart-double-gang-touch-light-switch_p0098812
 ---
 
 To enable standard (factory) functionality of the Status LED (displaying Wi-Fi Connection Status) add this Rule: 

--- a/_templates/deta_6914HA
+++ b/_templates/deta_6914HA
@@ -3,14 +3,14 @@ date_added: 2020-08-08
 title: Deta Fan Speed Controller with Light 
 model: 6914HA
 image: /assets/images/deta_6914HA.jpg
-template: '{"NAME":"Deta Fan Speed and Light Controller","GPIO":[18,0,0,157,23,19,0,0,0,22,21,24,17],"FLAG":0,"BASE":18}' 
-link: https://www.bunnings.com.au/deta-grid-connect-smart-fan-speed-controller-with-touch-light-switch_p0098815
-link2: 
 mlink: 
 flash: serial
 category: switch
 type: Switch
 standard: au
+template: '{"NAME":"Deta Fan Speed and Light Controller","GPIO":[18,0,0,157,23,19,0,0,0,22,21,24,17],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.com.au/deta-grid-connect-smart-fan-speed-controller-with-touch-light-switch_p0098815
+link2: https://www.bunnings.co.nz/deta-grid-connect-smart-fan-speed-controller-with-touch-light-switch_p0098815
 ---
 
 Decouple Buttons from Relays

--- a/_templates/deta_6922HA
+++ b/_templates/deta_6922HA
@@ -1,13 +1,14 @@
 ---
 date_added: 2019-11-02
 title: Deta 6922HA
+image: https://2ecffd01e1ab3e9383f0-07db7b9624bbdf022e3b5395236d5cf8.ssl.cf4.rackcdn.com/Product-1600x1600/0052c529-ef64-4075-b441-29ec04e08d6d.jpg
 category: plug
 type: Wall Outlet
 standard: au
-link: https://www.bunnings.com.au/deta-smart-double-power-point-touch-activated-switch-with-grid-connect_p0098813
-image: https://2ecffd01e1ab3e9383f0-07db7b9624bbdf022e3b5395236d5cf8.ssl.cf4.rackcdn.com/Product-1600x1600/0052c529-ef64-4075-b441-29ec04e08d6d.jpg
-template: '{"NAME":"DETA 2G GPO","GPIO":[0,0,0,0,157,0,0,0,91,21,22,0,90],"FLAG":0,"BASE":18}' 
 flash: tuya-convert
+link: https://www.bunnings.com.au/deta-smart-double-power-point-touch-activated-switch-with-grid-connect_p0098813
+Link2: https://www.bunnings.co.nz/deta-grid-connect-smart-double-touch-power-point_p0098813
+template: '{"NAME":"DETA 2G GPO","GPIO":[0,0,0,0,157,0,0,0,91,21,22,0,90],"FLAG":0,"BASE":18}' 
 ---
 
 

--- a/_templates/deta_6930HA
+++ b/_templates/deta_6930HA
@@ -1,13 +1,13 @@
 ---
 date_added: 2019-11-12
 title: Deta 6930HA
+image: https://media.bunnings.com.au/Product-800x800/09a8ffe1-ceac-456d-9bb4-58bbead2f489.jpg
 category: plug
 type: Plug
 standard: au
-link: https://www.bunnings.com.au/deta-smart-rewireable-plug-with-grid-connect_p0098810
-image: https://media.bunnings.com.au/Product-800x800/09a8ffe1-ceac-456d-9bb4-58bbead2f489.jpg
 template: '{"NAME":"DetaSmartPlug","GPIO":[0,17,0,0,0,0,0,0,0,56,21,0,0],"FLAG":0,"BASE":18}' 
-link2: 
+link: https://www.bunnings.com.au/deta-smart-rewireable-plug-with-grid-connect_p0098810
+link2: https://www.bunnings.co.nz/deta-grid-connect-smart-rewireable-plug_p0098810
 ---
 
 Tuya Convert 2

--- a/_templates/deta_DET018HA
+++ b/_templates/deta_DET018HA
@@ -3,12 +3,12 @@ date_added: 2020-05-01
 title: Deta 18W 1900lm T8 Tube
 model: DET018HA
 image: /assets/images/deta_DET018HA.jpg
-template: '{"NAME":"DETA Smart LED","GPIO":[0,0,0,0,0,0,0,0,0,0,37,0,0],"FLAG":0,"BASE":18}' 
-link: https://www.bunnings.co.nz/deta-smart-18w-1900lm-t8-tube-with-grid-connect_p0111511
-link2: 
 mlink: 
 flash: tuya-convert
 category: light
 type: Light
 standard: au
+template: '{"NAME":"DETA Smart LED","GPIO":[0,0,0,0,0,0,0,0,0,0,37,0,0],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.co.nz/deta-smart-18w-1900lm-t8-tube-with-grid-connect_p0111511
+link2: https://www.bunnings.co.nz/deta-grid-connect-smart-18w-t8-tube_p0111511
 ---

--- a/_templates/deta_DET902HA
+++ b/_templates/deta_DET902HA
@@ -3,12 +3,12 @@ date_added: 2020-02-03
 title: Deta DET902HA 10W 940lm RGB+CCT
 model: 9311644093183
 image: https://user-images.githubusercontent.com/5904370/73642352-dced2800-4671-11ea-8201-b7692f0175f6.png
-template: '{"NAME":"Deta DownLight","GPIO":[0,0,0,0,38,37,0,0,41,39,40,0,0],"FLAG":0,"BASE":18}' 
-link: https://www.bunnings.com.au/deta-10w-smart-led-downlight-with-grid-connect_p0102573
-link2: https://www.bunnings.com.au/deta-10w-smart-led-downlight-with-grid-connect_p0102573
 mlink: 
 flash: tuya-convert
 category: light
 type: Light
 standard: au
+template: '{"NAME":"Deta DownLight","GPIO":[0,0,0,0,38,37,0,0,41,39,40,0,0],"FLAG":0,"BASE":18}' 
+link: https://www.bunnings.com.au/deta-10w-smart-led-downlight-with-grid-connect_p0102573
+link2: https://www.bunnings.co.nz/deta-grid-connect-smart-10w-led-downlight_p0102573
 ---


### PR DESCRIPTION
Bunnings NZ now carries a wider range of the Arlec & Deta products.
PB Tech carries some of the Brilliant Smart range. 
File formatting re-arranged for consistency and grouping supplier links together.