### PR TITLE
Update feit_electric-BPA800RGBWAG2P

### DIFF
--- a/_templates/feit_electric-BPA800RGBWAG2P
+++ b/_templates/feit_electric-BPA800RGBWAG2P
@@ -7,7 +7,7 @@ category: bulb
 standard: e26
 link2: 
 image: /assets/images/feit_electric-BPA800RGBWAG2P.jpg
-template: '{"NAME":" BPA800/RGBW/AG/2P","GPIO":[0,0,0,0,37,38,0,0,141,142,140,0,0],"FLAG":0,"BASE":48}' 
+template: '{"NAME":"BPA800/RGBW/AG/2P","GPIO":[0,0,0,0,37,47,0,0,141,142,140,0,0],"FLAG":0,"BASE":48}' 
 link: https://www.amazon.com/dp/B07RL48PFF
 mlink: 
 ---


### PR DESCRIPTION
The PWM funtion of GPIO5 needs to be inverted for proper slider operation, so PWM2i is needed.
Also, there was a leading space in the name, which caused the last letter P to be truncated in the Tasmota GUI.
I deleted that leading space.