### PR TITLE
Add note about PSK 02 to MOKO YX-L01C-E14

### DIFF
--- a/_templates/moko_YX-L01C-E14
+++ b/_templates/moko_YX-L01C-E14
@@ -12,3 +12,4 @@ category: bulb
 type: RGBW
 standard: e14
 ---
+Sometime between 2020-03-31 and 2020-06-24 (date on barcode sticker) Moki started to use new tuya firmware with PSK 02, which cannot currently be flashed with tuya-convert.


### PR DESCRIPTION
Hello,

maybe this helps buyers of the bulb to determine if they can be flashed using tuya-convert before opening the package. I've ordered new bulbs hopefully predating 2020-06-24 so maybe I can narrow the date down.

Best regards,
Ben