### PR TITLE
Update Template name & link

### DIFF
--- a/_templates/brilex_BLX-DL-014-WHI
+++ b/_templates/brilex_BLX-DL-014-WHI
@@ -3,8 +3,8 @@ date_added: 2020-05-18
 title: Brilex Nightstand Lamp
 model: BLX-DL-014-WHI
 image: /assets/images/brilex_BLX-DL-014-WHI.jpg
-template: '{"NAME":"Smart Table La","GPIO":[0,0,18,0,37,157,0,0,38,17,39,0,40],"FLAG":0,"BASE":18}' 
-link: https://www.amazon.ca/Brilex-Compatible-Dimmable-Nightstand-Changing/dp/B08699YV77/
+template: '{"NAME":"Smart Table Lamp","GPIO":[0,0,18,0,37,157,0,0,38,17,39,0,40],"FLAG":0,"BASE":18}' 
+link: https://www.amazon.com/Brilex-Compatible-Dimmable-Nightstand-Changing/dp/B08699YV77/
 link2: 
 mlink: 
 flash: tuya-convert


### PR DESCRIPTION
It seems the template name got cut off and the amazon.ca link is broken but the .com link works fine