### PR TITLE
Update LC-ESP01-4R-12V

### DIFF
--- a/_templates/LC-ESP01-4R-12V
+++ b/_templates/LC-ESP01-4R-12V
@@ -18,7 +18,7 @@ You need to configure these rules to control the relays. The ones defined in the
 
 ```console
 rule1 
-on System#Boot do Backlog Baudrate 115200
+on System#Boot do Baudrate 115200 endon
 on SerialReceived#Data=41542B5253540D0A do SerialSend5 5749464920434f4e4e45435445440a5749464920474f542049500a41542b4349504d55583d310a41542b4349505345525645523d312c383038300a41542b43495053544f3d333630 endon
 on Power1#State=1 do SerialSend5 A00101A2 endon
 on Power1#State=0 do SerialSend5 A00100A1 endon


### PR DESCRIPTION
Added `endon` to the first line, which appears to be missing, and removed `Backlog` command that appears superfluous.