### PR TITLE
Update treatlife_DS03

### DIFF
--- a/_templates/treatlife_DS03
+++ b/_templates/treatlife_DS03
@@ -25,13 +25,14 @@ You can see if you're getting heartbeat messages from the Tuya MCU Chip by chang
 WebLog 4
 ```
 
-If you're getting messages that say something like `{"TuyaReceived":{"Data":"55AA030000010104","Cmnd":0,"CmndData":"01"}}` you don't need to change the baudrate. If you're seeing the ping to the MCU but no reply, you'll need to change the baudrate with the command below:
+If you're getting messages that say something like `{"TuyaReceived":{"Data":"55AA030000010104","Cmnd":0,"CmndData":"01"}}` you don't need to change the baudrate. If you're seeing the ping (such as `TYA: Send "55AA030000010104"`) to the MCU but no reply, you'll need to change the baudrate with the command below:
 
 ```console
 SetOption97 1
 ````
-This will set the baudrate to 115200. After this, you should start receiving heartbeat replies from the TuyaMCU, and the Red LED might come on for a few seconds.
+This will set the baudrate to 115200. After this, you should start receiving heartbeat replies from the TuyaMCU (like `TYA: Heartbeat`), and the Red LED might come on for a few seconds.
 
+Note that if you disassembled the switch to flash Tasmota via a serial connection, you may not see communication back from the MCU without reassembling the switch and connecting the switch to your mains power.
 
 There must be two sets of commands ran to make this work for both a fan and light. Additionally, the fan speed can only be controlled over MQTT or similar, unless custom rules are written.
 
@@ -69,41 +70,43 @@ Note about fan speed IDs: Lowest and Low are the same voltage output (I checked 
 
 Home Assistant Fan YAML:
 ```yaml
-- platform: mqtt
-  name: "TreatLife Fan"
-  state_topic: "stat/Treatlife-DS03/POWER1"
-  command_topic: "cmnd/Treatlife-DS03/POWER1"
-  speed_state_topic: "stat/Treatlife-DS03/speed"
-  speed_command_topic: "cmnd/Treatlife-DS03/TuyaSend4"
-  qos: 0
-  payload_on: 'ON'
-  payload_off: 'OFF'
-  payload_low_speed: '3,1'
-  payload_medium_speed: '3,2'
-  payload_high_speed: '3,3'
-  availability_topic: tele/Treatlife-DS03/LWT
-  payload_available: Online
-  payload_not_available: Offline
-  speeds:
-    - low
-    - medium
-    - high
+fan:
+  - platform: mqtt
+    name: "TreatLife Fan"
+    state_topic: "stat/Treatlife-DS03/POWER1"
+    command_topic: "cmnd/Treatlife-DS03/POWER1"
+    speed_state_topic: "stat/Treatlife-DS03/speed"
+    speed_command_topic: "cmnd/Treatlife-DS03/TuyaSend4"
+    qos: 0
+    payload_on: 'ON'
+    payload_off: 'OFF'
+    payload_low_speed: '3,1'
+    payload_medium_speed: '3,2'
+    payload_high_speed: '3,3'
+    availability_topic: tele/Treatlife-DS03/LWT
+    payload_available: Online
+    payload_not_available: Offline
+    speeds:
+      - low
+      - medium
+      - high
 ```
 Home Assistant Dimmer YAML:
 ```yaml
-- platform: mqtt
-  name: "TreatLife Dimmer"
-  state_topic: "stat/Treatlife-DS03/POWER2"
-  command_topic: "cmnd/Treatlife-DS03/POWER2"
-  availability_topic: "tele/Treatlife-DS03/LWT"
-  brightness_state_topic: "stat/Treatlife-DS03/RESULT"
-  brightness_command_topic: "cmnd/Treatlife-DS03/Dimmer"
-  brightness_scale: 100
-  brightness_value_template: "{{ value_json.Dimmer }}"
-  qos: 1
-  payload_on: "ON"
-  payload_off: "OFF"
-  payload_available: "Online"
-  payload_not_available: "Offline"
-  retain: false
+light:
+  - platform: mqtt
+    name: "TreatLife Dimmer"
+    state_topic: "stat/Treatlife-DS03/POWER2"
+    command_topic: "cmnd/Treatlife-DS03/POWER2"
+    availability_topic: "tele/Treatlife-DS03/LWT"
+    brightness_state_topic: "stat/Treatlife-DS03/RESULT"
+    brightness_command_topic: "cmnd/Treatlife-DS03/Dimmer"
+    brightness_scale: 100
+    brightness_value_template: "{{ value_json.Dimmer }}"
+    qos: 1
+    payload_on: "ON"
+    payload_off: "OFF"
+    payload_available: "Online"
+    payload_not_available: "Offline"
+    retain: false
 ```


### PR DESCRIPTION
Modified the (extremely helpful) example Home Assistant YAML to include the section of the configuration that the code applies to (i.e. "fan" and "light"), and included some additional example Tasmota Console readouts to help determine if you are successfully communicating with the MCU.  Added clarification that you may not receive MCU heartbeat unless the switch is assembled/installed/connected to mains.