### PR TITLE
Update Teckin SR40 image URL

### DIFF
--- a/_templates/teckin_SR40
+++ b/_templates/teckin_SR40
@@ -2,7 +2,7 @@
 date_added: 2020-02-13
 title: Teckin SR40
 model: RF-SR40-US
-image: /assets/images/teckin_RF-SR40-US.jpg
+image: /assets/images/teckin_SR40.jpg
 template: '{"NAME":"RF-SR40-US","GPIO":[158,0,0,17,56,18,0,0,22,21,57,23,0],"FLAG":0,"BASE":18}'
 link: https://smile.amazon.com/dp/B07RFPSZLG
 link2: 


### PR DESCRIPTION
Updates the Teckin SR40 image from [this](https://templates.blakadder.com/assets/images/teckin_RF-SR40-US.jpg) to [this](https://templates.blakadder.com/assets/images/teckin_SR40.jpg) as the old one was a 404. Seems like the new image is the same product, as shown from [it's Amazon page image](https://www.amazon.com/dp/B07RFPSZLG?tag=blakaddertemp-20&pldnSite=1).