### PR TITLE
Update blitzwolf_BW-LT21

### DIFF
--- a/_templates/blitzwolf_BW-LT21
+++ b/_templates/blitzwolf_BW-LT21
@@ -4,7 +4,7 @@ title: BlitzWolf 900lm
 model: BW-LT21 
 link: https://www.banggood.com/BlitzWolf-BW-LT21-RGBWW-10W-E27-APP-Smart-LED-Light-Bulb-Work-With-Amazon-Alexa-Google-Assistant-AC100-240V-p-1551059.html
 image: /assets/images/blitzwolf_BW-LT21.jpg
-template: '{"NAME":"BlitzWolf LT21","GPIO":[0,0,0,0,41,39,0,0,38,0,37,40,0],"FLAG":0,"BASE":18}'
+template: '{"NAME":"BlitzWolf LT21","GPIO":[0,0,0,0,0,39,0,0,38,0,37,40,0],"FLAG":0,"BASE":18}'
 link2: https://www.aliexpress.com/item/4000202082713.html
 link3: https://www.amazon.co.uk/dp/B07VMG193M
 mlink: https://www.blitzwolf.com/BlitzWolf-BW-LT21-Smart-Bulb-with-APP-Remote-Control,-16-Million-Colors,-3000K-Color-Temperature,-Adjustable-Brightness,-Voice-Control,-Scenes-Setting-p-379.html


### PR DESCRIPTION
There is no PWM5 channel in this device.
If one wants to use PWM4 channel from WEB interface one should use:
-SetOption37 128 (split RGB and W channel)
or
-SetOption106 1 (enable virtual PWM5 channel from RGB)