### PR TITLE
le_901001-US-a no longer compatible with Tasmota

### DIFF
--- a/_templates/le_901001-US-a
+++ b/_templates/le_901001-US-a
@@ -12,3 +12,4 @@ category: bulb
 type: RGBCCT
 standard: e26
 ---
+New models from Amazon now contain a Tuya WB2L instead of an ESP8266, so they are no longer compatible with Tasmota.


### PR DESCRIPTION
The WB2L has an ARM MCU so these bulbs are no longer compatible with Tasmota. Here's the data sheet for the WB2L - https://developer.tuya.com/en/docs/iot/device-development/module/wifibt-dual-mode-module/wb2l-datasheet?id=K9duegc9bualu