### PR TITLE
Update deta_6904HA

### DIFF
--- a/_templates/deta_6904HA
+++ b/_templates/deta_6904HA
@@ -8,7 +8,7 @@ flash: serial
 category: switch
 type: Switch
 standard: au
-template: '{"NAME":"Deta 4G Switch","GPIO":[157,0,0,19,18,21,0,0,23,20,22,24,17],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"Deta 4G Switch","GPIO":[158,0,0,19,18,21,0,0,23,20,22,24,17],"FLAG":0,"BASE":18}' 
 link: https://www.bunnings.com.au/deta-smart-touch-activated-quad-gang-light-switch-with-grid-connect_p0161015
 link2: https://www.bunnings.co.nz/deta-grid-connect-smart-quad-gang-touch-light-switch_p0161015
 ---


### PR DESCRIPTION
I think the status LED (led 5 on the PCB) is inverted.

I tried to assign it LED1, then LedPower1 state is inverted.
I had to assign it to LED1_i then LedPower1 state becomes correct.

So here I think we should assign GPIO0 to LedLink_i (158).
This might be the case for the other Deta wall switches too, but I only have a four gang one to test it on.