### PR TITLE
Update globe_50029

### DIFF
--- a/_templates/globe_50029
+++ b/_templates/globe_50029
@@ -3,7 +3,7 @@ date_added: 2020-07-02
 title: Globe 2-Outlet
 model: 50029
 image: /assets/images/globe_50029.jpg
-template: '{"NAME":"Globe SK509W2S","GPIO":[0,0,0,0,22,0,0,0,17,21,56,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"Globe 50029","GPIO":[0,0,0,57,22,157,0,0,17,21,56,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.homedepot.ca/product/globe-electric-wi-fi-smart-2-outlet-outdoor-plug-independently-controlled-grounded-outlets-1-pack-15a-/1001544416
 link2: 
 mlink: https://globe-electric.com/en/product/globe-electric-wi-fi-smart-2-outlet-outdoor-plug-no-hub-required-voice-activated-black-50029/


### PR DESCRIPTION
Added Led2i and LedLink so that each of the two leds indicate the power state of the corresponding relay

9.1 template {"NAME":"Globe 50029","GPIO":[0,0,0,321,225,544,0,0,32,224,320,0,0,0],"FLAG":0,"BASE":18}