### PR TITLE
Update powruia39

### DIFF
--- a/_templates/powruia39
+++ b/_templates/powruia39
@@ -7,6 +7,8 @@ template: '{"NAME":"Powrui AW-39","GPIO":[56,0,0,0,21,255,0,0,23,24,22,0,9],"FLA
 link: https://www.amazon.com/gp/product/B07KK62GB7
 image: https://user-images.githubusercontent.com/5904370/53308200-82fbb400-389f-11e9-80a8-6686b28539d4.png
 ---
+tuya-convert no longer working on Amazon inventory as of Dec 2020. Still using TYWES3 chipset, so serial still works. 
+```
 This allows you to turn on and off all the relays
 
 ```


### PR DESCRIPTION
tuya-convert no longer working on Amazon inventory as of Dec 2020. Still using TYWES3 chipset, so serial still works.