### PR TITLE
Update moko-switch

### DIFF
--- a/_templates/moko-switch
+++ b/_templates/moko-switch
@@ -7,7 +7,7 @@ standard: us
 flash: tuya-convert
 link: https://www.amazon.com/MoKo-Control-Compatible-Required-Installation/dp/B07VXVHDVD
 image: https://user-images.githubusercontent.com/5904370/70848523-28096c80-1e73-11ea-86c5-d44e7ba877b8.png
-template: '{"NAME":"Moko Switch","GPIO":[57,0,0,17,21,0,0,0,0,0,52,0,0],"FLAG":0,"BASE":59}' 
+template: '{"NAME":"Moko Switch (Single)","GPIO":[157,0,0,17,21,0,0,0,0,0,56,0,0],"FLAG":0,"BASE":59}' 
 link2: 
 ---
 


### PR DESCRIPTION
Use new LEDLink and LED1i to rather than LED1 and LED2i respectively.
And label as Single switch in preparation for adding Double and Triple MOKO switches.