### PR TITLE
Added MOKO Double and Triple switches.

### DIFF
--- a/moko-switch-2
+++ b/moko-switch-2
@@ -1,0 +1,11 @@
+---
+date_added: 2020-12-10
+title: MoKo Smart Life Double
+category: switch
+type: Switch
+standard: uk
+flash: tuya-convert
+link: https://www.amazon.co.uk/gp/product/B0834PFVTR
+template: '{"NAME":"Moko Switch (Double)","GPIO":[157,0,57,0,0,18,0,0,17,21,0,22,56],"FLAG":0,"BASE":59}' 
+link2: 
+---

--- a/moko-switch-3
+++ b/moko-switch-3
@@ -1,0 +1,11 @@
+---
+date_added: 2020-12-10
+title: MoKo Smart Life Triple
+category: switch
+type: Switch
+standard: uk
+flash: tuya-convert
+link: https://www.amazon.co.uk/gp/product/B0834PFVTR
+template: '{"NAME":"Moko Switch (Triple)","GPIO":[157,0,58,18,22,19,0,0,17,21,57,23,56],"FLAG":0,"BASE":59}' 
+link2: 
+---


### PR DESCRIPTION
Add Double and Triple MOKO switches.
Double switch is determined form an actual switch.  The triple mapping is determined from the double board and the single mappings.  Essentially the board has three positions for switches to be soldered 1, 2, 3.  Single switch uses position 2 as Switch1.  Double uses positions 1 (Switch1), 3 (Switch2) and triple uses all 3 in order.