### PR TITLE
Changed non-standard quote symbol

### DIFF
--- a/_templates/zemismart_YH002
+++ b/_templates/zemismart_YH002
@@ -4,7 +4,7 @@ title: Zemismart Blinds Controller
 model: YH002
 image: /assets/images/zemismart_YH002.jpg
 template: '{"NAME":"Zemismart Blin","GPIO":[255,255,255,255,255,255,0,0,255,108,255,107,255],"FLAG":0,"BASE":54}' 
-template9: '{"NAME":"Zemismart Blind”,”GPIO”:[1,1,1,1,1,1,0,0,1,2304,1,2272,1],”FLAG":0,"BASE":54}' 
+template9: '{"NAME":"Zemismart Blind","GPIO":[1,1,1,1,1,1,0,0,1,2304,1,2272,1],"FLAG":0,"BASE":54}' 
 link: https://www.aliexpress.com/item/4000782412838.html
 link2: 
 mlink: 


### PR DESCRIPTION
The template contains "left quotation marks" instead of the expected normal quotes. This causes problems when trying to configure Tasmota, which could waste a lot of time for the unwary.