### PR TITLE
Update Digoo DG-PS01

### DIFF
--- a/_templates/digoo_DG-PS01
+++ b/_templates/digoo_DG-PS01
@@ -15,5 +15,6 @@ link2: http://s.click.aliexpress.com/e/BA0bwuaM
 
 
 
+template for a diferent version of digoo DG-PS01 ( with status led of each socket conected to a gpio and not directly to the relay).
 
-
+{"NAME":"Digoo DG-PS01","GPIO":[544,0,0,321,225,320,0,0,322,226,227,224,64,0],"FLAG":0,"BASE":18}

--- a/_templates/digoo_DG-PS01
+++ b/_templates/digoo_DG-PS01
@@ -10,11 +10,8 @@ template: '{"NAME":"Digoo DG-PS01","GPIO":[0,56,0,17,23,22,0,0,0,24,21,0,0],"FLA
 link2: http://s.click.aliexpress.com/e/BA0bwuaM
 ---
 
-
-
-
-
-
 template for a diferent version of digoo DG-PS01 ( with status led of each socket conected to a gpio and not directly to the relay).
 
+```json
 {"NAME":"Digoo DG-PS01","GPIO":[544,0,0,321,225,320,0,0,322,226,227,224,64,0],"FLAG":0,"BASE":18}
+```


### PR DESCRIPTION
I have a Digoo DG-PS01, that i bought more then a year ago from banggood. just flashed with tasmota, and with the template in this page, only worked 2 relays and one status led. My power strip has 4 leds each of them connected a diferent gpio, and not tied directly to a relay.

Hope this could help someone!

Template {"NAME":"Digoo DG-PS01","GPIO":[544,0,0,321,225,320,0,0,322,226,227,224,64,0],"FLAG":0,"BASE":18}