### PR TITLE
Update minoston_MP22W

### DIFF
--- a/_templates/minoston_MP22W
+++ b/_templates/minoston_MP22W
@@ -13,3 +13,5 @@ type: Outdoor Plug
 standard: us
 ---
 Note: This device may have switched to the ARM based W2BS module which does not support tasmota.
+
+Purchased one from Amazon USA on 2020-12-22 and was not able to use tuya-convert. Has Bluetooth which is tip-off that it is no longer an ESP8266 inside.


### PR DESCRIPTION
Purchased one from Amazon USA on 2020-12-22 and was not able to use tuya-convert. Has Bluetooth which is tip-off that it is no longer an ESP8266 inside.