### PR TITLE
Update garage_door_controller

### DIFF
--- a/_templates/garage_door_controller
+++ b/_templates/garage_door_controller
@@ -1,6 +1,6 @@
 ---
 date_added: 2019-11-15
-title: Garage Door Controller
+title: Generic
 category: cover
 type: Garage Door Opener
 standard: global


### PR DESCRIPTION
Follow up on previous PR #850, after changing to type "Garage Door Opener" this shows up as "Garage Door Controller Garage Door Opener" in templates.

I thought very redundant, now just "Generic Garage Door Opener" if you agree. Thanks.