### PR TITLE
Update milfra_TB23

### DIFF
--- a/_templates/milfra_TB23
+++ b/_templates/milfra_TB23
@@ -3,7 +3,7 @@ date_added: 2020-02-06
 title: Milfra 3 Gang
 model: TB23
 image: /assets/images/milfra_TB23.jpg
-template9: '{"NAME":"Milfra TB23","GPIO":[320,320,289,290,34,33,0,0,225,224,226,0,32,0],"FLAG":0,"BASE":08}' 
+template9: '{"NAME":"Milfra TB23","GPIO":[320,320,289,290,34,33,0,0,225,224,226,0,32,0],"FLAG":0,"BASE":8}' 
 link: https://www.aliexpress.com/item/4000994263957.html
 link2: 
 mlink: https://www.milfra.com/


### PR DESCRIPTION
Leading zero in a numeric field is not valid JSON, probably due to this indicating octal in many programming languages, and octal is not a part of JSON specs.