### PR TITLE
Update hombli_duo

### DIFF
--- a/_templates/hombli_duo
+++ b/_templates/hombli_duo
@@ -3,7 +3,7 @@ date_added: 2020-11-14
 title: Hombli Socket Duo
 model: 
 image: /assets/images/hombli_duo.jpg
-template9: '{"NAME":"HombliSocketDuo","GPIO":[33,0,0,0,0,0,0,0,0,544,224,225,32,0,0],"FLAG":0,"BASE":18}' 
+template9: '{"NAME":"HombliSocketDuo","GPIO":[33,0,0,0,0,0,0,0,0,544,224,225,32,0],"FLAG":0,"BASE":18}' 
 link: https://www.aliexpress.com/item/1005001632168109.html
 link2: 
 mlink: https://shop.hombli.com/hombli-smart-socket-duo-eu


### PR DESCRIPTION
With 15 values in the gpio array, the html page gets an extra "GPIO014". As entering the malformed template in Tasmota removed the extra last pin of the array, I'm assuming that also removing this from the template works no worse than leaving it there, but not having the device I'm not able to verify if it works, before or after this change.