### PR TITLE
Update Be HiTech 16A model

### DIFF
--- a/_templates/be_hitech_16A
+++ b/_templates/be_hitech_16A
@@ -1,16 +1,17 @@
 ---
 date_added: 2020-11-13
 title: Be HiTech 16A
-model: SP1
+model: EU3S
 image: /assets/images/be_hitech_16A.jpg
 template: '{"NAME":"Be HiTech","GPIO":[0,0,0,52,0,134,0,0,131,17,132,21,0],"FLAG":0,"BASE":18}'
 template-alt: '{"NAME":"Be HiTech","GPIO":[0,0,56,0,0,134,0,0,131,17,132,21,0],"FLAG":0,"BASE":18}'
 template9: '{"NAME":"Be HiTech","GPIO":[0,0,0,288,0,2720,0,0,2624,32,2656,224,0],"FLAG":0,"BASE":18}'
 link: https://www.amazon.it/dp/B07VWXTMFB/
-link2: 
+link2: https://www.amazon.it/dp/B07VZ18XB2/
 mlink: 
 flash: tuya-convert
 category: plug
 type: Plug
 standard: eu
 ---
+Note: with part numbers SP1 and SP2 Amazon refers to the same device model ({{page.model}}), shipped in a single or double package, respectively.


### PR DESCRIPTION
Replace model name (erroneously reporting a part number referring to a single item package) with the actual one printed on the backside of the plug.