### PR TITLE
Y09 Sensor with additional TuyaReceived Cmd

### DIFF
--- a/_templates/Y09
+++ b/_templates/Y09
@@ -67,6 +67,10 @@ Check with `TuyaMCU` for the following configuration:
 ```console
 Rule1 ON TuyaReceived#Data=55AA0002000001 DO publish2 stat/%topic%/STATUS OPEN ENDON ON TuyaReceived#Data=55AA00050005010400010110 DO publish2 stat/%topic%/STATUS CLOSED ENDON
 ```
+Optionally: If OPEN/CLOSED seems *inverted*, one may also try the following alternative `Rule1`:
+```console
+Rule1 ON TuyaReceived#Data=55AA0002000001 DO publish2 stat/%topic%/STATUS CLOSED ENDON ON TuyaReceived#Data=55AA00050005010400010110 DO publish2 stat/%topic%/STATUS OPEN ENDON ON TuyaReceived#Data=55AA0005000501040001000F DO publish2 stat/%topic%/STATUS CLOSED ENDON
+```
 
 ```console
 Rule2 ON TuyaReceived#Data=55AA00050005030400010213 DO publish2 stat/%topic%/BATT high ENDON ON TuyaReceived#Data=55AA00050005030400010114 DO publish2 stat/%topic%/BATT medium ENDON ON TuyaReceived#Data=55AA00050005030400010015 DO publish2 stat/%topic%/BATT low ENDON


### PR DESCRIPTION
Added infos for Inverted OPEN/CLOSED case.
Specifically TuyaReceived#Data=55AA0005000501040001000F seems to be new, stating a CLOSED sensor during woke up phase of the device.