### PR TITLE
Cleverio 51395 alternate version

### DIFF
--- a/_templates/cleverio-51395
+++ b/_templates/cleverio-51395
@@ -5,6 +5,7 @@ link: https://www.kjell.com/no/produkter/smarte-hjem/smartbelysning/cleverio-sma
 image: /assets/images/cleverio-51395.jpg
 template: '{"NAME":"CleverioE27RGB","GPIO":[0,0,0,0,140,37,0,0,38,142,141,0,0],"FLAG":0,"BASE":18}' 
 template9: '{"NAME":"CleverioE27RGB","GPIO":[0,0,0,0,2944,2912,0,0,417,2976,416,0,0,0],"FLAG":0,"BASE":18}' 
+template9_alt: '{"NAME":"CleverioE27RGB,"GPIO":[0,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":18}'
 link2: 
 mlink: 
 flash: serial
@@ -13,7 +14,7 @@ type: RGBCCT
 standard: e27
 ---
 
-[TYLC6E](https://developer.tuya.com/en/docs/iot/device-development/module/wifi-module/lc-series-module/tylc6e?id=K97ottlp983f2) is the controlled used in the device.
+[TYLC6E](https://developer.tuya.com/en/docs/iot/device-development/module/wifi-module/lc-series-module/tylc6e?id=K97ottlp983f2) is the controller used in the device.
 
 To flash it, you will need to solder wires onto the solder pads labeled "RX", "TX", "IO0", "3V3" and "GND".
 "IO0" needs to be grounded for the device to enter flashing mode.
@@ -21,5 +22,5 @@ To flash it, you will need to solder wires onto the solder pads labeled "RX", "T
 Also, this device does not use SM16716 LED driver, but uses BP5778 and therefore uses PWM channels for all the colors + whites.
 `SetOption68 1` will have to be used to enable separate PWM control.
 
-Some versions use the [TYWE3L](https://developer.tuya.com/en/docs/iot/device-development/module/wifi-module/we-series-module/wifie3lpinmodule?id=K9605uj1ar87n) and the suitable template for this is:
-template: '{"NAME":"CleverioE27RGB,"GPIO":[0,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":18}'
+Some versions use the [TYWE3L](http://tasmota.github.io/docs/Pinouts/#tywe3l). Use alternate template for those.
+

--- a/_templates/cleverio-51395
+++ b/_templates/cleverio-51395
@@ -20,3 +20,6 @@ To flash it, you will need to solder wires onto the solder pads labeled "RX", "T
 
 Also, this device does not use SM16716 LED driver, but uses BP5778 and therefore uses PWM channels for all the colors + whites.
 `SetOption68 1` will have to be used to enable separate PWM control.
+
+Some versions use the [TYWE3L](https://developer.tuya.com/en/docs/iot/device-development/module/wifi-module/we-series-module/wifie3lpinmodule?id=K9605uj1ar87n) and the suitable template for this is:
+template: '{"NAME":"CleverioE27RGB,"GPIO":[0,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":18}'


### PR DESCRIPTION
Some versions use the [TYWE3L](https://developer.tuya.com/en/docs/iot/device-development/module/wifi-module/we-series-module/wifie3lpinmodule?id=K9605uj1ar87n) and the suitable template for this is:
template: '{"NAME":"CleverioE27RGB,"GPIO":[0,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":18}'