### PR TITLE
Alternate Gosund SW5 Template w/ red 'ON' LED

### DIFF
--- a/_templates/gosund_SW5
+++ b/_templates/gosund_SW5
@@ -4,6 +4,7 @@ title: Gosund Single Pole
 model: SW5
 image: /assets/images/gosund_SW5.jpg
 template9: '{"NAME":"Gosund SW5","GPIO":[32,0,320,0,0,0,0,0,0,0,224,0,576,0],"FLAG":0,"BASE":18}' 
+template9_alt: '{"NAME":"Gosund SW5","GPIO":[32,0,576,0,0,0,0,0,0,0,224,0,320,0],"FLAG":0,"BASE":18}' 
 link: https://www.amazon.com/gp/product/B0871JF1JZ/
 link2: 
 mlink: 
@@ -13,3 +14,4 @@ type: Switch
 standard: us
 ---
 Small solder pads inside of switch, all marked (IO0, TX, RX, 3.3V and GND)
+* Main template is for green 'ON' LED, alternate template is for red 'ON' LED similar to how the product comes from the factory


### PR DESCRIPTION
The way these outlets come from the factory- or at least the ones I received- are completely dark when 'OFF' and show a red LED when 'ON'.  The current template here shows a bright green LED instead.  I couldn't find a template that used the red LED, so I cooked up the `template9_alt` one above to do just that