### PR TITLE
Update ESP01

### DIFF
--- a/_templates/ESP01
+++ b/_templates/ESP01
@@ -3,7 +3,7 @@ date_added: 2020-04-24
 title: ESP-01 Module
 model: ESP-01
 image: /assets/images/ESP01.jpg
-template: '{"NAME":"ESP01","GPIO":[255,255,255,255,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"ESP01","GPIO":[255,255,1376,255,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.aliexpress.com/item/33005770320.html
 link2: https://www.amazon.de/dp/B074RL7YR3/
 link3: https://www.banggood.com/5pcs-ESP-01S-ESP8266-Serial-to-WiFi-Module-Wireless-Transparent-Transmission-Industrial-Grade-Smart-Home-Internet-of-Things-IOT-p-1493541.html
@@ -13,7 +13,6 @@ category: misc
 type: DIY
 standard: global
 ---
-[Differences between ESP-01 and ESP-01S](https://www.esp8266.com/viewtopic.php?t=1165)
 
 ![Pinout](/assets/images/ESP01-pinout.jpg)
 ![Wiring](/assets/images/ESP01-wiring.jpg)


### PR DESCRIPTION
1.) Pin used to drive WS2812 is GPIO2 of function type 1376
2.) the link to the ESP-01 and ESP-01S difference does not at all mention the ESP-01 but the ESP-07. That´s why I did remove that link