### PR TITLE
Update Dogain 320lm

### DIFF
--- a/_templates/dogain-4_5w
+++ b/_templates/dogain-4_5w
@@ -11,3 +11,6 @@ category: bulb
 type: RGBCCT
 standard: e12
 ---
+
+## Warning
+- As of March 2021 these bulbs come with Beken BK7231 chipset and are no longer compatible with Tasmota.


### PR DESCRIPTION
New bulbs contain a BK7231TQN32, as purchased on Amazon in March 2021. Not compatible with Tasmota as far as I can tell.  I took one apart - if anyone wants images let me know