### PR TITLE
Add Description for pins

### DIFF
--- a/_templates/shelly_2
+++ b/_templates/shelly_2
@@ -28,6 +28,8 @@ If the jumper is set to 12V you will destroy your Shelly!
 An ESP8266 with 2MB flash dual relay device with Energy Monitoring the size of round 45mm.<br>
 <img src="https://raw.githubusercontent.com/arendst/arendst.github.io/master/media/shelly/shelly2_serial_connection2.jpg" height="250" />
 
+Pins from top to bottom are: TX, RX, +3.3V, GPIO0, GND
+
 ## Templates as of v6.4.1.17
 The inbuilt template equals the following:<br>
 ``{"NAME":"Shelly 2","GPIO":[0,135,0,136,21,22,0,0,9,0,10,137,0],"FLAG":0,"BASE":47}``<br>


### PR DESCRIPTION
Took me a while to track down the order of the test points / pins.  I did find this image here:
https://github.com/arendst/Tasmota/issues/2789#issuecomment-415563022
However, found that TX and RX were reversed (eg, TX on the Shelly should be RX on the programmer.)  

This PR adds the correct order of the pins to this template to hopefully help others.