### PR TITLE
Updates to DETA 6914HA Fan Speed Controller with Light Switch

### DIFF
--- a/_templates/deta_6914HA
+++ b/_templates/deta_6914HA
@@ -102,8 +102,8 @@ Rule Logic
   payload_low_speed: "Event s=1"
   payload_medium_speed: "Event s=2"
   payload_high_speed: "Event s=3"
-  payload_off: 'OFF'
-  payload_on: 'ON'
+  payload_off: "Event p=0"
+  payload_on: "Event p=1"
   speeds:
     - low
     - medium

--- a/_templates/deta_6914HA
+++ b/_templates/deta_6914HA
@@ -8,7 +8,7 @@ flash: serial
 category: switch
 type: Switch
 standard: au
-template: '{"NAME":"Deta Fan Speed and Light Controller","GPIO":[18,0,0,157,23,19,0,0,0,22,21,24,17],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"Deta Fan Speed and Light Controller","GPIO":[18,0,0,158,23,19,0,0,0,22,21,24,17],"FLAG":0,"BASE":18}'
 link: https://www.bunnings.com.au/deta-grid-connect-smart-fan-speed-controller-with-touch-light-switch_p0098815
 link2: https://www.bunnings.co.nz/deta-grid-connect-smart-fan-speed-controller-with-touch-light-switch_p0098815
 ---
@@ -20,36 +20,49 @@ SetOption73 1
 
 Single rule to handle fan speed logic
 ```console
-rule1
-ON SYSTEM#Init DO VAR1 3 ENDON
-ON BUTTON1#State=10 DO POWER1 Toggle ENDON
-ON BUTTON2#State=10 DO POWER2 Toggle ENDON
-ON POWER2#State=1 DO POWER3 ON ENDON
-ON POWER2#State=1 DO POWER4 ON ENDON
-ON POWER2#State=1 DO VAR1 2 ENDON
-ON POWER2#State=0 DO POWER3 OFF ENDON
-ON POWER2#State=0 DO POWER4 OFF ENDON
-ON POWER2#State=0 DO VAR1 3 ENDON
-ON BUTTON3#State=10 DO Event SetSpeed=%VAR1% ENDON
-ON EVENT#SetSpeed=1 DO POWER3 OFF ENDON
-ON EVENT#SetSpeed=1 DO POWER4 OFF ENDON
-ON EVENT#SetSpeed=1 DO POWER2 ON ENDON
-ON EVENT#SetSpeed=1 DO VAR1 3 ENDON
-ON EVENT#SetSpeed=2 DO POWER3 OFF ENDON
-ON EVENT#SetSpeed=2 DO POWER4 ON ENDON
-ON EVENT#SetSpeed=2 DO POWER2 ON ENDON
-ON EVENT#SetSpeed=2 DO VAR1 1 ENDON
-ON EVENT#SetSpeed=3 DO POWER3 ON ENDON
-ON EVENT#SetSpeed=3 DO POWER4 ON ENDON
-ON EVENT#SetSpeed=3 DO POWER2 ON ENDON
-ON EVENT#SetSpeed=3 DO VAR1 2 ENDON
+Rule1
+ON SYSTEM#Init DO Backlog var1 3; var2 1 ENDON
+ON BUTTON1#State=10 DO power1 Toggle ENDON
+ON BUTTON2#State=10 DO event p=%var2% ENDON
+ON BUTTON3#State=10 DO event s=%var1% ENDON
+ON EVENT#p>0 DO power4 ON ENDON
+ON EVENT#p>0 DO power3 ON ENDON
+ON EVENT#p>0 DO power2 ON ENDON
+ON EVENT#p>0 DO var1 2 ENDON
+ON EVENT#p>0 DO var2 0 ENDON
+ON EVENT#p=0 DO power3 OFF ENDON
+ON EVENT#p=0 DO power4 OFF ENDON
+ON EVENT#p=0 DO power2 OFF ENDON
+ON EVENT#p=0 DO var1 3 ENDON
+ON EVENT#p=0 DO var2 1 ENDON
+ON EVENT#s>0 DO var2 0 ENDON
+ON EVENT#s=1 DO power3 OFF ENDON
+ON EVENT#s=1 DO power4 OFF ENDON
+ON EVENT#s=1 DO power2 ON ENDON
+ON EVENT#s=1 DO var1 3 ENDON
+ON EVENT#s=2 DO power3 OFF ENDON
+ON EVENT#s=2 DO power4 ON ENDON
+ON EVENT#s=2 DO power2 ON ENDON
+ON EVENT#s=2 DO var1 1 ENDON
+ON EVENT#s=3 DO power3 ON ENDON
+ON EVENT#s=3 DO power4 ON ENDON
+ON EVENT#s=3 DO power2 ON ENDON
+ON EVENT#s=3 DO var1 2 ENDON
+ON POWER2#State=0 DO power4 OFF ENDON
+ON POWER2#State=0 DO power3 OFF ENDON
+ON POWER2#State=0 DO var1 3 ENDON
+ON POWER2#State=0 DO var2 1 ENDON
+ON POWER2#State=1 DO power4 ON ENDON
+ON POWER2#State=1 DO power3 ON ENDON
+ON POWER2#State=1 DO var1 2 ENDON
+ON POWER2#State=1 DO var2 0 ENDON
 ```
 
 Enable rule with `Rule1 1`
 
 Description:
 `SetOption73` Decouples the buttons and relay
-The VAR1 can be thought of as "NextSpeed", if it makes it easier to read the code
+The VAR1 can be thought of as "NextSpeed" and VAR2 as "Next Power", if it makes it easier to read the code
 
 Notes:
 - Relay 1 is the main light relay controlled by button1 (the light button)
@@ -58,8 +71,10 @@ Notes:
 - Relay 4 is the tertiary fan relay not physically connected to any buttons
 
 Rule Logic
-- Relay 3 and4 will always turn on with Relay 2
+- Relay 3 and 4 will always turn on with Relay 2
 - VAR1 is set to 3 at Initialisation and when the fan is powered off to ensure full power to fan to startup
+- VAR2 is set to 1 at Initialisation to control the fan "next power state"
+- Button 2 will always toggle the power to the fan (and reset state)
 - Button 3 will always decrease speed one at a time 3 -> 2 -> 1 -> 3
 
 ### Home Assistant
@@ -69,24 +84,24 @@ Rule Logic
 - platform: mqtt
   name: Bedroom Fan
   state_topic: tele/tasmota-7540/STATE
-  command_topic: cmnd/tasmota-7540/POWER2
+  command_topic: cmnd/tasmota-7540/Backlog
   state_value_template: "{{ value_json.POWER2 }}"
   speed_command_topic: cmnd/tasmota-7540/Backlog
   speed_state_topic: tele/tasmota-7540/STATE
   speed_value_template: >
     {% if value_json.POWER3 == 'OFF' and value_json.POWER4 == 'OFF' %}
-      Event SetSpeed=1
+      Event s=1
     {% elif value_json.POWER3 == 'OFF' and value_json.POWER4 == 'ON' %}
-      Event SetSpeed=2
+      Event s=2
     {% elif value_json.POWER3 == 'ON' and value_json.POWER4 == 'ON' %}
-      Event SetSpeed=3
+      Event s=3
     {% endif %}
   availability_topic: tele/tasmota-7540/LWT
   payload_available: Online
   payload_not_available: Offline
-  payload_low_speed: "Event SetSpeed=1"
-  payload_medium_speed: "Event SetSpeed=2"
-  payload_high_speed: "Event SetSpeed=3"
+  payload_low_speed: "Event s=1"
+  payload_medium_speed: "Event s=2"
+  payload_high_speed: "Event s=3"
   payload_off: 'OFF'
   payload_on: 'ON'
   speeds:

--- a/_templates/deta_6914HA
+++ b/_templates/deta_6914HA
@@ -83,9 +83,14 @@ Rule Logic
 {% raw %}
 - platform: mqtt
   name: Bedroom Fan
-  state_topic: tele/tasmota-7540/STATE
   command_topic: cmnd/tasmota-7540/Backlog
-  state_value_template: "{{ value_json.POWER2 }}"
+  state_topic: tele/tasmota-7540/STATE
+  state_value_template: >
+    {% if value_json.POWER2 == 'ON' %}
+      Event p=1
+    {% else %}
+      Event p=0
+    {% endif %}
   speed_command_topic: cmnd/tasmota-7540/Backlog
   speed_state_topic: tele/tasmota-7540/STATE
   speed_value_template: >


### PR DESCRIPTION
- Invert the LinkLed so it's not always on
- Optimise the rule to reduce delay turning relays 3 and 4 on after relay 2 when using the button or events.

Note that to add the additional event for fan power toggle, I needed to reorder the rule lines, use lower case and shorten the event names to fit everything in a single rule.
Interestingly, the same rule set in a different line order or with upper case causes the Tasmota unishox compression to be less efficient.



I found that with 5 minute telemetry, the power state in HA can be a bit laggy, but sending power and speed commands works as expected. The rule is flexible enough to handle someone sending commands to POWER2 instead of sending events, but the relay 3 and 4 response will be slightly delayed as it is before this change.