### PR TITLE
Update Home Assistant Config for 2021.4 Changes

### DIFF
--- a/_templates/luci-connect-remote-control
+++ b/_templates/luci-connect-remote-control
@@ -30,23 +30,28 @@ Enable rule with `Rule1 1`
   name: "Flat Bedroom Fan"
   state_topic: "stat/flatbedfan/POWER1"
   command_topic: "cmnd/flatbedfan/POWER1"
-  speed_state_topic: "stat/flatbedfan/speed"
-  speed_command_topic: "cmnd/flatbedfan/TuyaSend4"
+  payload_on: "ON"
+  payload_off: "OFF"
+  availability_topic: "tele/flatbedfan/LWT"
+  payload_available: "Online"
+  payload_not_available: "Offline"
+  preset_mode_state_topic: "stat/flatbedfan/speed"
+  preset_mode_value_template: >
+    {%- if value == '2,0' %}low
+    {%- elif value == '2,1' %}medium
+    {%- elif value == '2,2' %}high
+    {%- endif -%}
+  preset_mode_command_topic: "cmnd/flatbedfan/TuyaSend4"
+  preset_mode_command_template: >
+    {%- if value == "low" %}2.0
+    {%- elif value == "medium" %}2,1
+    {%- elif value == "high" %}2,2
+    {%- endif -%}
   qos: 0
-  payload_on: 'ON'
-  payload_off: 'OFF'
-  payload_oscillation_on: 'ON'
-  payload_oscillation_off: 'OFF'
-  payload_low_speed: '2,0'
-  payload_medium_speed: '2,1'
-  payload_high_speed: '2,2'
-  availability_topic: tele/flatbedfan/LWT
-  payload_available: Online
-  payload_not_available: Offline
-  speeds:
-    - low
-    - medium
-    - high
+  preset_modes:
+    - "low"
+    - "medium"
+    - "high"
 ```
 
 5. Add the following to Home Assistant to your `light` section (if required):


### PR DESCRIPTION
Home Assistant 2021.4 contained changes to the MQTT Fan platform:

The fan entity model has been changed. This impacts the way the MQTT Fan supports speeds and the following configuration options are deprecated and will be removed in Home Assistant Core 2021.7.0:

    speed_command_topic
    speed_state_topic
    state_value_template
    speed_list

Additionally,preset_modes and percentage are added to replace the legacy model supporting only three speeds low, medium and high. Therefore, command templates for state, oscillation, preset_mode and percentage are introduced.