### PR TITLE
GD-30W: fix typo

### DIFF
--- a/_templates/GD-30W
+++ b/_templates/GD-30W
@@ -98,7 +98,7 @@ binary_sensor:
     device_class: problem
     availability_topic: "tele/%topic%/LWT"
     payload_available: "Online"
-    payload_not_avail: "Offline"
+    payload_not_available: "Offline"
 ```
 
 ### PCB


### PR DESCRIPTION
Change payload_not_avail to payload_not_available in the Home Assistant binary sensor configuration.