### PR TITLE
Added possible rule

### DIFF
--- a/_templates/minoston_MS10W
+++ b/_templates/minoston_MS10W
@@ -18,3 +18,5 @@ Backlog TuyaMCU 11,1; TuyaMCU 21,3;
 ```console
 DimmerRange 25,255
 ```
+In some cases, when the ```Power OFF``` toggle isn't working correctly, a rule can be added to fix the problem.
+```Rule1 ON power1#state=0 DO Backlog Power OFF; Dimmer 0 ENDON```


### PR DESCRIPTION
Some versions of this switch ignore a Power OFF command without a `Dimmer 0` appended. The rule at the bottom allows for this to happen and for the light to turn on and off consistently.