### PR TITLE
Update hbn_U151T with incompatible module

### DIFF
--- a/_templates/hbn_U151T
+++ b/_templates/hbn_U151T
@@ -12,3 +12,8 @@ category: plug
 type: Outdoor Plug
 standard: us
 ---
+### Warning
+New units appear to be shipping with the WB2S module installed, which is not compatible with Tasmota.  
+The daughter board could be desoldered and replaced, but it would be challenging to fit in the small case.
+
+Purchased from Amazon 5-22-2021: Contains incompatible WB2S module

--- a/_templates/hbn_U151T
+++ b/_templates/hbn_U151T
@@ -11,6 +11,7 @@ flash: serial
 category: plug
 type: Outdoor Plug
 standard: us
+unsupported: true
 ---
 ### Warning
 New units appear to be shipping with the WB2S module installed, which is not compatible with Tasmota.  


### PR DESCRIPTION
U151T plugs are now shipping with WB2S modules which cannot be updated with Tasmota. Added a warning to the page description, and updated with my purchase date and location.