### PR TITLE
AOFO C730: Add tuya-convert notice

### DIFF
--- a/_templates/aofo_4AC4USB
+++ b/_templates/aofo_4AC4USB
@@ -1,6 +1,7 @@
 ---
 date_added: 2021-03-14
 title: AOFO 4AC 4USB
+model: C730
 category: plug
 type: Power Strip
 standard: eu
@@ -10,6 +11,8 @@ image: /assets/images/aofo_4AC4USB.jpg
 template: '{"NAME":"AOFO4AC4USB","GPIO":[0,56,0,17,22,21,0,0,23,24,25,0,0],"FLAG":0,"BASE":18}' 
 template9: '{"NAME":"AOFO4AC4USB-EU","GPIO":[0,320,0,32,228,227,0,0,225,224,226,0,0,0],"FLAG":0,"BASE":18}' 
 ---
+Recent devices come with a newer Tuya firmware and tuya-convert does not currently support it.
+
 TYWE2S module inside
 
 In some cases Relay5 (USB) ON/OFF is inverted.


### PR DESCRIPTION
I bought this device on amazon.de just a few days ago, and it turns out tuya-convert doesn't support the revision I have yet:
```
Your device's firmware is too new.                                                                                                                                                                    
Tuya patched the PSK vulnerability that we use to establish a connection.                                                                                                                             
You might still be able to flash this device over serial.                                                                                                                                             
For more information and to follow progress on solving this issue see:                                                                                                                                
https://github.com/ct-Open-Source/tuya-convert/wiki/Collaboration-document-for-PSK-Identity-02
```

While at it, also add the model to the template.