### PR TITLE
fix LED

### DIFF
--- a/_templates/geeni_GN-SW003-199S
+++ b/_templates/geeni_GN-SW003-199S
@@ -3,7 +3,7 @@ date_added: 2020-05-31
 title: Geeni SURGE 6-Outlet Surge Protector
 model: GN-SW003-199S
 image: /assets/images/geeni_GN-SW003-199S.jpg
-template9: '{"NAME":"Geeni 6 Strip","GPIO":[288,0,289,0,225,224,0,0,227,228,226,229,32,0],"FLAG":0,"BASE":18}' 
+template9: '{"NAME":"Geeni 6 Strip","GPIO":[320,0,0,0,225,224,0,0,227,228,226,229,32,0],"FLAG":0,"BASE":18}' 
 link: https://www.amazon.com/Geeni-6-Outlet-Protector-Assistant-Microsoft/dp/B07DB3W915/
 link2: 
 mlink: https://mygeeni.com/collections/power/products/geeni-gn-sw003-199-surge-smart-protector-white


### PR DESCRIPTION
Found problems with LED config. Looking at pcb traces, GPIO2 is not connected to anything, its missing a via, and GPIO0 is controlling both LEDs. So have to set the GPIO2 to none so firmware can actually show error conditions accurately.