### PR TITLE
Update Geeni Mini Surge Strip

### DIFF
--- a/_templates/geeni-GN-SW004-199
+++ b/_templates/geeni-GN-SW004-199
@@ -12,3 +12,7 @@ category: plug
 type: Power Strip
 standard: us
 ---
+
+**Update 6 June 2021:** The Geeni Surge Mini is now being sold with the incompatible Tuya WB3S chip.
+
+It is possible to successfully desolder this chip from the daughterboard (e.g. with a heat gun) and replace it with an ESP-12F to continue using the template on this page.

--- a/_templates/geeni-GN-SW004-199
+++ b/_templates/geeni-GN-SW004-199
@@ -11,6 +11,7 @@ flash: tuya-convert
 category: plug
 type: Power Strip
 standard: us
+unsupported: true
 ---
 
 **Update 6 June 2021:** The Geeni Surge Mini is now being sold with the incompatible Tuya WB3S chip.


### PR DESCRIPTION
No longer a Tasmota-compatible chip.