### PR TITLE
Wyze Plug Flasher -> esp2ino

### DIFF
--- a/_layouts/templates.html
+++ b/_layouts/templates.html
@@ -66,7 +66,7 @@ layout: default
     <a class="menu" href="https://github.com/arendst/mgos-to-tasmota" target="_blank">MgOS to Tasmota</a>
     {% elsif page.flash == "preflashed" %}
     Tasmota pre-flashed
-    {% elsif page.flash == "e2i" %}
+    {% elsif page.flash == "esp2ino" %}
     <a class="menu" href="https://github.com/elahd/esp2ino" target="_blank">esp2ino</a>
     {% else %}
     {% endif %}

--- a/_layouts/templates.html
+++ b/_layouts/templates.html
@@ -66,8 +66,8 @@ layout: default
     <a class="menu" href="https://github.com/arendst/mgos-to-tasmota" target="_blank">MgOS to Tasmota</a>
     {% elsif page.flash == "preflashed" %}
     Tasmota pre-flashed
-    {% elsif page.flash == "wpf" %}
-    <a class="menu" href="https://github.com/elahd/wyze_plug_flasher" target="_blank">Wyze Plug Flasher</a>
+    {% elsif page.flash == "e2i" %}
+    <a class="menu" href="https://github.com/elahd/esp2ino" target="_blank">esp2ino</a>
     {% else %}
     {% endif %}
   {% else %}

--- a/_templates/wyze_WLPA19
+++ b/_templates/wyze_WLPA19
@@ -6,7 +6,7 @@ image: /assets/images/wyze_WLPA19.jpg
 template9: '{"NAME":"Wyze Bulb","GPIO":[5728,0,0,0,0,0,0,0,0,416,417,0,0,0],"FLAG":0,"BASE":48}'
 link: https://www.amazon.com/dp/B07RF9NCDP
 mlink: https://wyze.com/wyze-bulb.html
-flash: wpf
+flash: esp2ino
 category: bulb
 type: CCT
 standard: e26

--- a/_templates/wyze_WLPP1
+++ b/_templates/wyze_WLPP1
@@ -7,7 +7,7 @@ template: '{"NAME":"WyzePlugWLPP1","GPIO":[0,0,0,0,0,56,0,0,21,0,17,0,0],"FLAG":
 link: https://www.amazon.com/dp/B07XZT24B8
 link2: 
 mlink: https://wyze.com/wyze-plug.html
-flash: wpf
+flash: esp2ino
 category: plug
 type: Plug
 standard: us


### PR DESCRIPTION
Wyze Plug Flasher project has been renamed esp2ino.

Formerly https://github.com/elahd/wyze_plug_flasher
Now https://github.com/elahd/esp2ino

Updating references here w/ new project name and URL.