### PR TITLE
Update luci-connect-remote-control

### DIFF
--- a/_templates/luci-connect-remote-control
+++ b/_templates/luci-connect-remote-control
@@ -44,7 +44,7 @@ Enable rule with `Rule1 1`
     {%- endif -%}
   preset_mode_command_topic: "cmnd/flatbedfan/TuyaSend4"
   preset_mode_command_template: >
-    {%- if value == "low" %}2.0
+    {%- if value == "low" %}2,0
     {%- elif value == "medium" %}2,1
     {%- elif value == "high" %}2,2
     {%- endif -%}


### PR DESCRIPTION
There was a . instead of a , which rendered the LOW functionality NON functional. Line 47 relates