### PR TITLE
Added internal RST button to Shelly i3

### DIFF
--- a/_templates/shelly_i3
+++ b/_templates/shelly_i3
@@ -3,7 +3,7 @@ date_added: 2020-07-22
 title: Shelly i3 Action and Scenes Activation Device
 model: 
 image: /assets/images/shelly_i3.jpg
-template: '{"NAME":"Shelly i3","GPIO":[0,0,0,0,17,56,0,0,83,84,82,0,0],"FLAG":2,"BASE":18}' 
+template: '{"NAME":"Shelly i3","GPIO":[0,0,0,0,0,56,0,0,83,84,82,0,0],"FLAG":2,"BASE":18}' 
 link: https://www.amazon.de/dp/B089GWDS19/
 link2: https://www.domadoo.fr/fr/objets-communicants/5288-shelly-module-d-activation-de-scenesactions-wi-fi-shelly-i3-3809511202593.html
 link3: https://www.aliexpress.com/item/1005002821587581.html
@@ -13,6 +13,7 @@ category: relay
 type: Switch Module
 standard: global
 ---
+Internal RST button is located on GPIO4 but not entered in the template until tested.
 
 ## Configuration
 After flashing Tasmota, the Shelly i3 will publish all events of each of the three inputs via "stat/%topic%/POWER" (ON/OFF). But there is no separate POWER1, POWER2 and POWER3. That means that you can only distinguish the state of each switch via the SENSOR data, that is only published every few minutes, but not instantly.

--- a/_templates/shelly_i3
+++ b/_templates/shelly_i3
@@ -3,7 +3,7 @@ date_added: 2020-07-22
 title: Shelly i3 Action and Scenes Activation Device
 model: 
 image: /assets/images/shelly_i3.jpg
-template: '{"NAME":"Shelly i3","GPIO":[0,0,0,0,0,56,0,0,83,84,82,0,0],"FLAG":2,"BASE":18}' 
+template: '{"NAME":"Shelly i3","GPIO":[0,0,0,0,17,56,0,0,83,84,82,0,0],"FLAG":2,"BASE":18}' 
 link: https://www.amazon.de/dp/B089GWDS19/
 link2: https://www.domadoo.fr/fr/objets-communicants/5288-shelly-module-d-activation-de-scenesactions-wi-fi-shelly-i3-3809511202593.html
 link3: https://www.aliexpress.com/item/1005002821587581.html


### PR DESCRIPTION
Added internal RST button to Shelly i3

Not tested in Tasmota, found in own firmware, is component 17 the right GPIO config for GPIO 4?
Component says "Button active low, internal pull-up resistor"
The button needs to be pulled-up and 0 is pressed, 1 is not pressed.