### PR TITLE
Update for Youngzuth SW03-02 with WB3S

### DIFF
--- a/_templates/sana_SW02-02
+++ b/_templates/sana_SW02-02
@@ -12,3 +12,5 @@ type: Switch
 standard: us
 ---
 Same things as noted by SANA SW02-03 template author: GPIO0 Not exposed (used for LED) makes reset difficult if it is ever needed. Tuya-Convert compatible as of this writing.
+
+Edit 08/28/2021 : A similar unit, the Youngzuth SW02-03, has been seen with an (unsupportable) WB3S inside.

--- a/_templates/sana_SW02-03
+++ b/_templates/sana_SW02-03
@@ -12,3 +12,5 @@ link2:
 
 GPIO0 Not exposed (used for LED) makes reset difficult if it is ever needed. Tuya-Covert compatible as of this writing.
 
+Edit 08/28/2021 : A similar unit, the Youngzuth SW02-03, has been seen with an (unsupportable) WB3S inside.
+

--- a/_templates/youngzuth_SW02-03
+++ b/_templates/youngzuth_SW02-03
@@ -10,6 +10,7 @@ image: /assets/images/youngzuth_3in1.jpg
 template: '{"NAME":"SW02 3W","GPIO":[56,0,0,19,23,18,0,0,17,21,0,22,0],"FLAG":0,"BASE":18}'
 link2: 
 ---
+Edit 08/28/2021 : Purchased from Amazon, and unit has a (unsupportable) WB3S inside. It may be possible to swap this module with a  ESP-12, but has not been tested.
 
 
 

--- a/_templates/youngzuth_SW02-03
+++ b/_templates/youngzuth_SW02-03
@@ -9,13 +9,6 @@ link: https://www.amazon.com/gp/product/B07Q5XPRKD
 image: /assets/images/youngzuth_3in1.jpg
 template: '{"NAME":"SW02 3W","GPIO":[56,0,0,19,23,18,0,0,17,21,0,22,0],"FLAG":0,"BASE":18}'
 link2: 
+unsupported: true
 ---
 Edit 08/28/2021 : Purchased from Amazon, and unit has a (unsupportable) WB3S inside. It may be possible to swap this module with a  ESP-12, but has not been tested.
-
-
-
-
-
-
-
-


### PR DESCRIPTION
I got an Youngzuth 3in1 Switch, SW03-02, and it has a WB3S in it. As I understand it, it's unsupportable, but can be physically swapped with an ESP12. 

The first commit updates the Youngzuth directly, the second updates two very similar-looking Sana devices that may be affected the same way.

Hopefully the format of the edits look OK.