### PR TITLE
Update luminea_ZX-2858

### DIFF
--- a/_templates/luminea_ZX-2858
+++ b/_templates/luminea_ZX-2858
@@ -3,7 +3,7 @@ date_added: 2020-02-03
 title: Luminea ZX-2858
 model: ZX-2858-675
 image: https://user-images.githubusercontent.com/5904370/73696849-743b9500-46dd-11ea-8b72-5e9a581828ea.png
-template: '{"NAME":"Luminea SF-200","GPIO":[0,0,0,17,0,0,0,0,0,56,21,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"ZX2858-675","GPIO":[32,0,0,0,2688,2656,0,0,2624,320,224,0,0,0],"FLAG":0,"BASE":65}' 
 link: https://www.pearl.de/a-ZX2858-3103.shtml?vid=675
 link2: 
 mlink: https://www.luminea.info/Ultrakompakte-WiFi-Steckdose-Adapter-mit-Energie-ZX-2858-919.shtml


### PR DESCRIPTION
Changed the template to actually include the power meter and use the right GPIO for the button (GPIO0 and not GPIO3 as it was before)