### PR TITLE
Update gosund_SW6

### DIFF
--- a/_templates/gosund_SW6
+++ b/_templates/gosund_SW6
@@ -3,7 +3,7 @@ date_added: 2020-07-21
 title: Gosund SW6 3-Way
 model: SW6
 image: /assets/images/gosund_SW6.jpg
-template: '{"NAME":"Gosund SW6","GPIO":[17,0,56,0,9,0,0,0,0,0,22,21,158],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"Gosund SW6","GPIO":[161,0,320,0,160,0,0,0,0,226,225,224,576,0],"FLAG":0,"BASE":18}' 
 link: https://www.amazon.com/dp/B085TG46KN
 link2: 
 mlink: https://www.alibaba.com/product-detail/White-US-Standard-Smart-Home-Products_1600196665148.html
@@ -20,9 +20,10 @@ This assumes standard 3-way lighting with a child 'dumb' toggle switch connected
 Component | Description. 
 --------- | -----------  
 Relay1 | A dummy component that stores the power state of the switch.  
-Relay2 | The actual hardware switch.  
-Button1 | It's exactly what you think it is. When pushing the button it automatically TOGGLES Power1. 
-Switch1 | The secondary switch electrically controls the light, and its state changes on Switch1.  
+Relay2 | The actual hardware switch. This controls the state of the circuit (on|off) but, is not a direct indiction of the state of the circuit. The relay could be on while the ciruit is open.  
+Relay3 | A dummy component used to process external commands. This is necessary to allow explicit control of the state of the circuit. It should always be in the same state as Relay 1. 
+Switch1 | The status of the circuit. Switch1's state will change when the circuit changes. As an example say relay2 is off, the circuit is closed, and Switch1's state will is 1. If relay2 is toggled to on the circuit will open and Switch1's state will change to 0.  
+Switch2 | The push button on the smart switch. Using Switch instead of button seems to provide a quicker response. 
 
 ### Device Configuration
 There are a couple things we need to do to get this switch to work correctly. 
@@ -36,10 +37,12 @@ SwitchTopic 0
 For more information about SwitchTopic you can find it here: https://tasmota.github.io/docs/Buttons-and-Switches/#switchtopic
 
 #### SwitchMode
-Setting this to 1 allows for the switch to be a toggle and not just 1 or a 0
+Setting Switch 1 to SwitchMode 1 will keep Relay 1 in sync with the status of the power. When the state of the cirucit is changed that will change Switch1 and in turn chagne Relay1.
+Setting Switch 2 to SwitchMode 5 will allow it to toggle the power and gives access to the HOLD option.
 
 ```console
-switchmode1 1
+switchmode1 0
+switchmode2 5
 ```
 
 For more information about SwitchMode you can find it here: https://tasmota.github.io/docs/Buttons-and-Switches/#switchmode
@@ -47,24 +50,20 @@ For more information about SwitchMode you can find it here: https://tasmota.gith
 ### Rules Configuration
 
 #### Rule1
-Updates the state of the dummy relay when switch1 changes state.
+When relay 3 changes state this will toggle relay 2. If relay 3 doesn't change state when then nothging happens. 
 ```console
-Backlog Rule1 ON Switch1#state do Power1 2 endon; Rule1 1
+Backlog Rule1 ON Power3#State do Power2 2 endon; Rule1 1
 ```
 
 #### Rule2
-Toggles Power2 when the button is pressed.
+Keeps relay3 in synch with relay1 but, rule1 has to be disabled while updateing the state and then reenabled. 
 ```console
-Backlog Rule2 ON Button1#state do Power2 2 endon; Rule2 1
+Backlog Rule2 ON Power1#state do Backlog rule1 0; power3 0; rule 1 1 endon On Powe1#state=1 do Backlog rule1 0: power3 1: rule1 1 endon; Rule2 1
 ```
 #### Rule3
-If the device is sent an EVENT it will Toggle Power2. 
+For explicit on / off and toggle rule3. When an event is received Relay3 will only change if it's not already in the matching state.
 ```console
-Backlog Rule3 ON event#OFF do power2 2 endon ON event#ON do power2 2 endon; Rule3 1
-```
-For explicit on / off and toggle rule3
-```console
-Backlog Rule3 ON event#OFF do power2 0 endon ON event#ON do power2 1 endon ON event#TOGGLE do power2 2 endon; Rule3 1
+Backlog Rule3 ON event#OFF do power3 0 endon ON event#ON do power3 1 endon ON event#TOGGLE do power3 2 endon; Rule3 1
 ```
 
 For more information about Rules you can find it here: https://tasmota.github.io/docs/Rules/

--- a/_templates/gosund_SW6
+++ b/_templates/gosund_SW6
@@ -41,9 +41,11 @@ Setting Switch 1 to SwitchMode 1 will keep Relay 1 in sync with the status of th
 Setting Switch 2 to SwitchMode 5 will allow it to toggle the power and gives access to the HOLD option.
 
 ```console
-switchmode1 0
+switchmode1 1 
 switchmode2 5
 ```
+
+**** If when everything is setup the switch status in inversed then use the command "switchmode1 2".  Switch 1 is inverted due to the way the switch was wired in the cirucit.****
 
 For more information about SwitchMode you can find it here: https://tasmota.github.io/docs/Buttons-and-Switches/#switchmode
 

--- a/_templates/gosund_SW6
+++ b/_templates/gosund_SW6
@@ -52,7 +52,7 @@ For more information about SwitchMode you can find it here: https://tasmota.gith
 #### Rule1
 When relay 3 changes state this will toggle relay 2. If relay 3 doesn't change state when then nothging happens. 
 ```console
-Backlog Rule1 ON Power3#State do Power2 2 endon; Rule1 1
+Backlog Rule1 ON Power3#State do Power2 2 endon ON switch2#state=3 DO publish stat/tasmota_XXXXX/SWITCH1T {"TRIG":"HOLD"} ENDON; Rule1 1
 ```
 
 #### Rule2


### PR DESCRIPTION
The current (non-explicit) configuration of gosund_SW6 worked when using toggle commands.  The problem comes when trying to control a group.  If an off command was sent but, the gosund was already off it would toggle to on.

The current (explicit) configuration had similar problem in that if the relay was off but the circuit was on nothing would change when receiving an off command. This means the switch would only take external commands if relay2's state matched the current state of the circuit.  

This new change adds another relay which will change to match external commands. It is also kept in sync with the state of the circuit so that if an OFF command was received nothing happens.  Using relay1 won't work because it will cause a loop in certain circumstances since it is set to match the status of the circuit.