### PR TITLE
gpios.html appears to have a small editing mishap

### DIFF
--- a/_includes/gpios.html
+++ b/_includes/gpios.html
@@ -633,10 +633,8 @@
                 {% when "237" %}
                 Relay 14
                 {% when "238" %}
-                Relay 14
-                {% when "239" %}
                 Relay 15
-                {% when "240" %}
+                {% when "239" %}
                 Relay 16
                 {% when "256" %}
                 Relay_i 1


### PR DESCRIPTION
Scraping this, I noticed this segment:
```
                Relay 13
                {% when "237" %}
                Relay 14
                {% when "238" %}
                Relay 14
                {% when "239" %}
                Relay 15
                {% when "240" %}
                Relay 16
```
Relay 14 is duplicated, and this pushes the next numbers off what I see when configuring in Tasmota, where Relay 16 is component 239, and so on. Additionally, I wondered why the numbers do not go all the way to 28, which the dropdown in Tasmota32 allows?

Ignoring this, I also noticed that Button_tc appears twice, same number. The dropdown in Tasmota allows up to 8 of these.