### PR TITLE
Use base module 48 for PWM CT

### DIFF
--- a/_templates/bneta_IO-WIFI60-B22P
+++ b/_templates/bneta_IO-WIFI60-B22P
@@ -3,7 +3,7 @@ date_added: 2020-05-22
 title: BNETA 8.5W 800lm
 model: IO-WIFI60-B22P
 image: /assets/images/bneta_IO-WIFI60-B22P.jpg
-template: '{"NAME":"BNETA IO-WIFI60-E27P","GPIO":[0,0,0,0,37,40,0,0,38,50,39,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"BNETA IO-WIFI60-E27P","GPIO":[0,0,0,0,37,40,0,0,38,50,39,0,0],"FLAG":0,"BASE":48}' 
 link: https://www.takealot.com/bneta-iot-smart-wifi-led-bulb-b22-8-5w-colour-warm-cool-white/PLID60542775/product-information
 link2: 
 mlink: https://www.bneta.co.za/product/smartbulb_e27/


### PR DESCRIPTION
I flashed Tasmota 9.5.0 onto my Bneta lamp (https://www.takealot.com/bneta-iot-smart-wifi-led-bulb-e27-8-5w-colour-warm-cool-white/PLID60542773), over serial, using wires I soldered to the opened lamp.

![20211012_215239](https://user-images.githubusercontent.com/948278/137107876-354913d0-000b-41ac-846e-455a6bf9e194.jpg)

Following the [guide to add a new device to Tasmota](https://tasmota.github.io/docs/Configuration-Procedure-for-New-Devices/#finding-relays-and-lights) results in this pin mapping.
| GPIO | Colour | PWM nr |
| -- | -- | -- |
| 4 | Red | 1 |
| 5 | White on/off | 4 |
| 12 | Green | 2 |
| 13 | OFF=Warm, ON=Cool | 5 (inverted) |
| 14 | Blue | 3 |
| 15 | ?? | none |
| 16 | ?? | none |

Initially my colour control would switch the light off when set to warm. Reading these docs (https://tasmota.github.io/docs/Lights/#pwm-ct) pointed me to `SetOption92 1`. That solved the problem.

The alternative to Option92 is to base this lamp on module 48. This PR changes the base module to 48.