### PR TITLE
Update sonoff_S26R2

### DIFF
--- a/_templates/sonoff_S26R2
+++ b/_templates/sonoff_S26R2
@@ -25,6 +25,9 @@ mlink: https://sonoff.tech/product/wifi-smart-plugs/s26
 
 This upgraded version is recognized by the "Max..." text printed on the front (Text differs depending on the type of plug).
 
+S26R2TPF has a Espressif Systems 1MB ESP8285 on a small daughter board with no visible connection. Connections points for serial interface is on the backside of the main board labeled V for 3.3v, TX, RX and GND.
+Success with Tasmotizer 1.2, image 10.0.0 and a CP2102 serial programmer.
+
 ![](/assets/images/sonoff_S26R2_label.jpg)
 
 ![](/assets/images/sonoff_S26R2_models.jpg)


### PR DESCRIPTION
The inside of the S26R2TPF did not look like the pictures off the S26 available online. It took me some time to find the connections.
I’m totally new to Tasmoto and also new to github so if the entry is stupid the please ignore it.
I have pictures of the inside but I have no clue how to add it to “/assets/images/” 

https://www.styrahem.se/p/711/strombrytare-paav-wifi-sonoff-s26-r2

![Back side with labels](https://user-images.githubusercontent.com/32602435/140815869-29e0c36a-7cc5-4359-8a18-58edbbc67015.jpg)
![Back side with wires](https://user-images.githubusercontent.com/32602435/140815873-662de9b1-7472-4f2e-8167-1f6ece129bd9.jpg)
![6](https://user-images.githubusercontent.com/32602435/140816085-e10b30d8-f9b6-43bd-9969-bf2ccb65775c.jpg)
r2