### PR TITLE
Update lilygo_T5-4_7

### DIFF
--- a/_templates/lilygo_T5-4_7
+++ b/_templates/lilygo_T5-4_7
@@ -18,7 +18,7 @@ link3: https://www.amazon.com/dp/B08WCPRX2P/
 extends                 = env:tasmota32_base
 board                   = esp32_16M
 build_flags             = ${env:tasmota32_base.build_flags} -DFIRMWARE_EPD47 -DCONFIG_EPD_DISPLAY_TYPE_ED047TC1 -DCONFIG_EPD_BOARD_REVISION_LILYGO_T5_47
-lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_i2c, lib/lib_display, lib/libesp32_lvgl, lib/libesp32_epdiy,
+lib_extra_dirs          = lib/libesp32, lib/lib_basic, lib/lib_i2c, lib/lib_display, lib/libesp32_lvgl, lib/libesp32_epdiy
 ```
 
 `user_config_override.h`


### PR DESCRIPTION
Removed komma, which prevented the epdiy library from beeing used in compilation.