### PR TITLE
Updating link for module replacement instructions (Treatlife DP20)

### DIFF
--- a/_templates/treatlife_DP20
+++ b/_templates/treatlife_DP20
@@ -14,4 +14,4 @@ flash: replace
 chip: WB3S
 ---
 
-[Module replacement and configuration instructions](https://imgur.com/a/EPMrvOM)
+[Module replacement and configuration instructions](https://www.digiblur.com/2020/12/treatlife-dual-indoor-dimmable-smart.html)


### PR DESCRIPTION
Original link goes to a rickroll on imgur.  I've linked to a more helpful set of instructions.