### PR TITLE
Move ZN281402 to unsupported devices

### DIFF
--- a/_templates/ZN281402
+++ b/_templates/ZN281402
@@ -8,10 +8,13 @@ link: https://www.aliexpress.com/item/1005001902324888.html
 link2: https://www.aliexpress.com/item/1005001896157964.html
 mlink:
 flash: serial
-category: misc
+category: unsupported
 type: IR Controller
 standard: global
 ---
+
+Warning: As of November 2021 this device does not include a Tasmota-compatible chip
+
 Open the device and you will promptly see the TX, RX, GND, 3.3V and GPIO0 pads. Just solder jumper cables to these pins and flash. It uses the same template as [this device](https://templates.blakadder.com/ytf_ir_bridge.html). NOTE: The device I bought keeps making a "humming" sound that bothers me. I dont know if that's a problem with my device only.
 
 ![Packaging](/assets/images/ZN281402_packaging.jpg)

--- a/_templates/ZN281402
+++ b/_templates/ZN281402
@@ -8,8 +8,9 @@ link: https://www.aliexpress.com/item/1005001902324888.html
 link2: https://www.aliexpress.com/item/1005001896157964.html
 mlink:
 flash: serial
-category: unsupported
+category: misc
 type: IR Controller
+unsupported: true
 standard: global
 ---
 


### PR DESCRIPTION
The chip included has an incompatible physical layout to suit any Tasmota-supported chip

![2021-11-28_17-55-21-4530](https://user-images.githubusercontent.com/8725013/143733192-015b4986-2e20-4b80-b42f-0b8c603152d5.jpg)

![2021-11-28_18-05-05-4531](https://user-images.githubusercontent.com/8725013/143733196-a5866e99-d32a-42a7-b084-f681b8e38a47.jpg)

Second image demonstrates the incompatibility of the PCB with an ESP-12F module
