### PR TITLE
Template type for ESP32

### DIFF
--- a/_templates/wyze_WLPA19C
+++ b/_templates/wyze_WLPA19C
@@ -3,7 +3,7 @@ date_added: 2021-06-30
 title: Wyze Bulb Color
 model: WLPA19C
 image: /assets/images/wyze_WLPA19C.jpg
-template9: '{"NAME":"Wyze Bulb Color","GPIO":[0,0,0,0,0,0,0,0,0,418,416,419,0,0,0,0,0,0,0,224,0,0,417,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}' 
+template32: '{"NAME":"Wyze Bulb Color","GPIO":[0,0,0,0,0,0,0,0,0,418,416,419,0,0,0,0,0,0,0,224,0,0,417,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}' 
 link: https://www.amazon.com/dp/B08WZ5THJ7/
 link2: 
 mlink: https://wyze.com/wyze-bulb-color.html


### PR DESCRIPTION
From what I can tell, "template9" means ESP8266 with new component numbers, not ESP32 which mostly should be "template32". Correct?