### PR TITLE
Template type for new component numbers

### DIFF
--- a/_templates/electriq_CD12PW
+++ b/_templates/electriq_CD12PW
@@ -3,7 +3,7 @@ date_added: 2021-01-06
 title: electriQ 12L Portable
 model: CD12PW
 image: /assets/images/electriq_CD12PW.jpg
-template: '{"NAME":"electriQ CD12PW","GPIO":[0,2272,0,2304,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":54}' 
+template9: '{"NAME":"electriQ CD12PW","GPIO":[0,2272,0,2304,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":54}' 
 link: https://www.amazon.co.uk/dp/B07KT8YHZB
 link2: 
 mlink: https://www.electriq.co.uk


### PR DESCRIPTION
Seems like using "template" instead of "template9" for new component numbers screws up the GPIO decoding on the web page.