### PR TITLE
Update shelly_plug_S

### DIFF
--- a/_templates/shelly_plug_S
+++ b/_templates/shelly_plug_S
@@ -15,7 +15,8 @@ link4: https://www.aliexpress.com/item/1005002963468034.html
 link5: https://www.idealo.de/preisvergleich/OffersOfProduct/200332967_-plug-s-shelly.html
 ---
 
+## Serial Connection
+Shelly Plug S has an programming header inside. 
+Details can be found here: 
 
-
-
-
+https://faulty.cloud/blog/shelly-plug-s-pinout


### PR DESCRIPTION
I was looking for a description for the Serial Link Socket. 
I find it using trial and error. 
This is my image 
![shelly_plug_s](https://user-images.githubusercontent.com/69294005/144659846-294cef25-3769-406c-bd3d-db3892b3fb9f.png)


Today i found an image in the net. 
https://faulty.cloud/blog/shelly-plug-s-pinout

