### PR TITLE
Add note that new Wyze devices are not easy to do OTA with esp2ino any more

### DIFF
--- a/_templates/wyze_WLPA19
+++ b/_templates/wyze_WLPA19
@@ -11,6 +11,7 @@ category: bulb
 type: CCT
 standard: e26
 ---
+Note: Per esp2ino latest update, it might difficult or impossible to flash newly acquired Wyze devices over-the-air.
 
 **Requires Tasmota 9.2+**
 

--- a/_templates/wyze_WLPP1
+++ b/_templates/wyze_WLPP1
@@ -12,6 +12,8 @@ category: plug
 type: Plug
 standard: us
 ---
+Note: Per esp2ino latest update, it might difficult or impossible to flash newly acquired Wyze devices over-the-air.
+
 Uses 15 amp relay and an edge mounted daughter board for the ESP8266EX. LED will light when relay is engaged. Side button will toggle the relay state.
 
 ## Serial Flashing


### PR DESCRIPTION
esp2ino repo now says:

> __Wyze recently changed their API in a way that prevents esp2ino from being loaded onto their devices.__ If you're technically inclined, see [this GitHub issue](https://github.com/HclX/WyzeUpdater/issues/9#issuecomment-885030254) for a workaround. Otherwise, check back here for updates...

I thought about removing the esp2ino link altogether, but I see a minor value in keeping it, both for historical reasons, and because it might be revived someday.  Or of course, because it should still work for older devices.