### PR TITLE
Diffuser - payload_not_avail invalid command

### DIFF
--- a/_templates/oil_diffuser_550ml
+++ b/_templates/oil_diffuser_550ml
@@ -105,7 +105,7 @@ binary_sensor:
     device_class: problem
     availability_topic: "tele/%topic%/LWT"
     payload_available: "Online"
-    payload_not_avail: "Offline"
+    payload_not_available: "Offline"
 ```
 
 ## PCB


### PR DESCRIPTION
payload_not_avail tosses error in home assistant. Changed it to payload_not_available