### PR TITLE
include a tasmota rule

### DIFF
--- a/_templates/liectroux_C30B
+++ b/_templates/liectroux_C30B
@@ -22,6 +22,11 @@ Once the ESP8266 is installed and flashed with Tasmota, select TuyaMCU module an
 Backlog Module 54; SetOption66 1
 ``` 
 
+Activate also this rule to inform the TuyaMCU that the WiFi connection is ok (this eliminates the problem with wifi module rebooting all the time):
+```console
+Backlog Rule1 1; Rule1 on TuyaReceived#Cmnd=43 do SerialSend5 55aa002b0001042f endon
+``` 
+
 ```json
 MCU Product ID: {"p":"imk0pcrtmyx9cbfg","v":"1.2.2","m":1}
 {"TuyaReceived":{"Data":"55AA03070005010100010112","Cmnd":7,"CmndData":"0101000101","DpType1Id1":1,"1":{"DpId":1,"DpIdType":1,"DpIdData":"01"}}}


### PR DESCRIPTION
```{"TuyaReceived":{"Data":"55AA032B00002D","Cmnd":43}}```

that line kept appearing all the time in the console. it's the MCU asking for the wifi module for wifi status. if the module doesn't respond for 90s, the MCU reboots the wifi module. 
the module should respond with:

```SerialSend5 55aa002b0001042f```

i made a rule for that:

```Backlog Rule1 1; Rule1 on TuyaReceived#Cmnd=43 do SerialSend5 55aa002b0001042f endon```

now the wifi LED in the vacuum even lights up and the module is up for hours since then