### PR TITLE
Nous A1T: correct and add new template

### DIFF
--- a/_templates/nous_A1T
+++ b/_templates/nous_A1T
@@ -1,9 +1,10 @@
 ---
 date_added: 2022-01-04
-title: Nous 16A 
+title: Nous A1T with Tasmota
 model: A1T
 image: /assets/images/nous_A1T.jpg
-template9: '{"NAME":"NOUS A1T","GPIO":[17,0,0,0,134,132,0,0,131,56,21,0,0],"FLAG":0,"BASE":49}' 
+template: '{"NAME":"NOUS A1T","GPIO":[17,0,0,0,134,132,0,0,131,56,21,0,0],"FLAG":0,"BASE":49}'
+template9: '{"NAME":"NOUS A1T","GPIO":[32,0,0,0,2720,2656,0,0,2624,320,224,0,0],"FLAG":0,"BASE":49}'
 link: https://www.amazon.de/gp/product/B0054PSIPA
 link2: 
 mlink: https://nous.technology/product/a1t.html

--- a/_templates/nous_A1T
+++ b/_templates/nous_A1T
@@ -1,6 +1,6 @@
 ---
 date_added: 2022-01-04
-title: Nous A1T with Tasmota
+title: Nous 16A
 model: A1T
 image: /assets/images/nous_A1T.jpg
 template: '{"NAME":"NOUS A1T","GPIO":[17,0,0,0,134,132,0,0,131,56,21,0,0],"FLAG":0,"BASE":49}'


### PR DESCRIPTION
- template9 -> template, as it uses the old GPIO numbers (before Version 9) - I hope the name template is right?
- add the template9 with converted, new GPIO numbers (for Version 9 and above) - tested with Version 10
- change title to "Nous A1T with Tasmota" as on official manfacture web page
