### PR TITLE
Fixed tuya version on newer version of LVWIT G45

### DIFF
--- a/_templates/lvwit_G45
+++ b/_templates/lvwit_G45
@@ -16,3 +16,5 @@ standard: e14
 
 Instructions in the box were wrong: To get into Discovery Mode -  Don’t wait 10 seconds. Turn bulb on & off 3 times and wait 
 
+Newer version, probably called "G45-2", isn't flashable with tuya-convert. Opening it might be as bad as with Feit Electric A19.
+


### PR DESCRIPTION
I bought these to flash them, but tuya-convert wasn't able to flash them. I'll probably return them again.

> Attempting to diagnose the issue...
> Your device's firmware is too new.
> Tuya patched the PSK vulnerability that we use to establish a connection.
> You might still be able to flash this device over serial.

Was the "2" on the OG devices, too?
![PXL_20220118_192502427_cropped](https://user-images.githubusercontent.com/2297270/150005333-f2ccccd7-a702-4061-b873-37f8f6c02415.jpg)
![20220118_175845_5658771826846620896](https://user-images.githubusercontent.com/2297270/150005335-3b8e5ca8-c737-43ed-84d2-33db894715e2.jpg)
![20220118_181140_6538873961585531833](https://user-images.githubusercontent.com/2297270/150005337-7294f37d-6eef-4534-b17f-0677b5dfe4f7.jpg)

