### PR TITLE
Update zemismart_KS-811_3gang

### DIFF
--- a/_templates/zemismart_KS-811_3gang
+++ b/_templates/zemismart_KS-811_3gang
@@ -12,6 +12,8 @@ link3: https://www.amazon.com.au/Zemismart-Compatible-Assistant-Incandescent-Req
 image: /assets/images/zemismart_KS-811_3gang.jpg
 template: '{"NAME":"KS-811 Triple","GPIO":[0,0,56,0,19,18,0,0,22,21,23,0,17],"FLAG":0,"BASE":18}' 
 mlink: https://www.zemismart.com/zemismart-us-wifi-wall-push-light-switch-alexa-google-home-enable-smart-life-app-controlone-gang-two-gangs-three-gangs_p0163.html
+unsupported: true
+chip: BK7231N 
 ---
 
 New from Factory (Feb '19) has patched firmware blocking Tuya-Convert

--- a/_templates/zemismart_KS-811_3gang
+++ b/_templates/zemismart_KS-811_3gang
@@ -15,6 +15,7 @@ mlink: https://www.zemismart.com/zemismart-us-wifi-wall-push-light-switch-alexa-
 ---
 
 New from Factory (Feb '19) has patched firmware blocking Tuya-Convert
+New from Factory (Jan '22) board version KS811_B_V02 does not have an ESP8266 chipset but rather a Beken BK7231N chipset, which is totally incompatible with Tasmota.
 
 Flash Instructions: Unscrew 4 screws on rear, use serial to flash. Ground IO0 while booting to get into flash mode.
 


### PR DESCRIPTION
Advise new purchasers that new versions are totally incompatible with Tasmota as they no longer contain an ESP8266 chipset