### PR TITLE
Added template to ESP-12 to show which IOs are available

### DIFF
--- a/_templates/ESP-12
+++ b/_templates/ESP-12
@@ -3,6 +3,7 @@ date_added: 2021-09-04
 title: ESP-12E / ESP-12F / ESP-12S
 model: ESP-12
 image: /assets/images/ESP-12.jpg
+template: '{"NAME":"ESP-12","GPIO":[1,0,1,0,1,1,0,0,1,1,1,1,1,0],"FLAG":0,"BASE":18}'
 link: https://www.aliexpress.com/item/1005001320458012.html
 link2: https://www.banggood.com/ESP8266-ESP-12E-Remote-Serial-Port-WIFI-Transceiver-Wireless-Module-p-980984.html
 link3: https://www.amazon.com/dp/B07SYNS21H/


### PR DESCRIPTION
The following pins are available on ESP-12 modules:
- GPIO00
- GPIO02
- GPIO04
- GPIO05
- GPIO12
- GPIO13
- GPIO14
- GPIO15
- GPIO16

I have set them to "User" and the others to "None".
