### PR TITLE
Update MOES MS-105 which now uses WB2S

### DIFF
--- a/_templates/moes-MS-105-1
+++ b/_templates/moes-MS-105-1
@@ -3,11 +3,13 @@ date_added: 2019-12-29
 title: Moes MS-105-1 v2
 link: https://www.aliexpress.com/item/4000436821697.html
 link2: https://www.amazon.de/gp/product/B083SCY56D
+link3: https://www.alza.de/moes-hidden-wlan-smart-dimmer-schalter-2-gang-d6294780.htm
+link4: https://www.aliexpress.com/item/1005002258602359.html
 image: /assets/images/moes-MS-105-1.jpg
 template: '{"NAME":"MS-105","GPIO":[0,107,0,108,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":54}' 
-link2: https://www.alza.de/moes-hidden-wlan-smart-dimmer-schalter-2-gang-d6294780.htm
 mlink: https://www.moeshouse.com/products/diy-smart-wifi-light-led-dimmer-switch-smart-life-tuya-app-remote-control-1-2-way-switch-works-with-alexa-echo-google-home-1
-flash: tuya-convert
+flash: replace
+chip: WB2S
 category: relay
 type: Dimmer Module
 standard: global


### PR DESCRIPTION
I have bought it from Aliexpress in May/2021:
https://www.aliexpress.com/item/1005002258602359.html 

I've opened it and it now comes with the chip WB2S as well. 
Same as the [moes_MS-105B](https://github.com/blakadder/templates/blob/62f6686ab4755dfbc16ce0cb269ba129590a69df/_templates/moes_MS-105B)
