### PR TITLE
Fix battery topic path

### DIFF
--- a/_templates/TY01
+++ b/_templates/TY01
@@ -77,7 +77,7 @@ Sensor status will be mapped to POWER. ON is "open" and OFF is "closed".
 There is no function in Tasmota for battery power dpID so we will use a rule to report battery status (high, medium or low) to a custom topic (change it to any other topic suitable for you). 
 
 ```console
-Rule1 ON TuyaReceived#Data=55AA00050005030400010213 DO publish2 stat/%topic%/BATT high ENDON ON TuyaReceived#Data=55AA00050005030400010112 DO publish2 stat/%topic%/BATT medium ENDON ON TuyaReceived#Data=55AA00050005030400010011 DO publish2 stat/%topic%/BATT low ENDON
+Rule1 ON TuyaReceived#Data=55AA00050005030400010213 DO publish2 stat/%topic%/BATTERY high ENDON ON TuyaReceived#Data=55AA00050005030400010112 DO publish2 stat/%topic%/BATTERY medium ENDON ON TuyaReceived#Data=55AA00050005030400010011 DO publish2 stat/%topic%/BATTERY low ENDON
 ```
 Don't forget to turn on the rule: `Rule1 1`
 


### PR DESCRIPTION
The path for battery state that is announced in the home assistant auto config do not match the actual publish path.