### PR TITLE
New hardware version found with WB2S

### DIFF
--- a/_templates/nedis_WIFIPO120FWT
+++ b/_templates/nedis_WIFIPO120FWT
@@ -9,17 +9,20 @@ flash: replace
 mlink: https://nedis.com/en-us/product/550710067/wi-fi-smart-outdoor-plug-splashproof-ip44-power-monitor-schuko-type-f-16-a
 image: /assets/images/nedis_WIFIPO120FWT.jpg
 template: '{"NAME":"WIFIPO120FWT","GPIO":[17,0,0,0,133,132,0,0,131,56,21,0,0],"FLAG":0,"BASE":49}' 
-template9: '{"NAME":"WIFIPO120FWT","GPIO":[32,0,0,0,2688,2656,0,0,2624,320,224,0,0,0],"FLAG":0,"BASE":49}'
+template9: '{"NAME":"WIFIPO120FWT","GPIO":[0,0,0,32,2720,2656,0,0,2624,320,224,0,0,0],"FLAG":0,"BASE":49}'
 link: https://www.amazon.de/dp/B07VHBR3WL
 link2: https://webshop.nedis.com/en-us/550710067/wifipo120fwt
 unsupported: true
-chip: WB3S
+chip: WB3S / WB2S
 ---
 
 ## Hardware Revision
 Boxes with visible Alexa logo have the new version with the WB3S chip.
 
 ![New box](https://user-images.githubusercontent.com/40159019/142038975-a230bf62-0a24-4c08-af8f-5073dbc432fb.jpg)
+
+## Hardware Revision #2
+Newer version of device bought in January 2022 with WB2S chip. Box was identical to the previous version. WB2S was replaced with direct replacement TYWE2S (ESP-02s) and button pin was on the GPIO03 (labeled as RX on silkscreen). Energy metering chip was identified as BL0937.
 
 ## Opening
 Remove the two security screws on the backside. Pry open from the top of the connector rounding on the backside. Two plastic clamps holding it together at the top and at the bottom. A bit of force is needed. When opened, remove the four screws from the PCB and the soldering points are clearly marked and accessible at the bottom PCB.


### PR DESCRIPTION
New version with WB2S chip found. Direct replacement TYWE2S  was used and button pin was found to be at GPIO03. Energy metering chip identified as BL0937 and was able to accurately calibrate power monitoring when using BL0937 CF (2720) -option.