### PR TITLE
Update antsig HUBIR01HA Incompatible device

### DIFF
--- a/_templates/antsig_HUBIR01HA
+++ b/_templates/antsig_HUBIR01HA
@@ -17,7 +17,7 @@ unsupported: true
 
 ## Warning! Since 2022-03-19 ships with an incompatible Tuya CB3S. If the box says "HUBIR01HA Series 2" its likley its the incompatible chip.
 
-It might be possible to replace the incompatible CB3S chip with a [ESP-12 S/E/F](https://templates.blakadder.com/ESP-12.html). 
+It is possible to replace the incompatible CB3S chip with a [ESP-12 S/E/F](https://templates.blakadder.com/ESP-12.html). If you do, depending on your chip you may need to pull GPIO15 down to ground with a 10k resistor for the ESP device to boot
 
 ## Old hardware instructions
 

--- a/_templates/antsig_HUBIR01HA
+++ b/_templates/antsig_HUBIR01HA
@@ -11,5 +11,14 @@ flash: serial
 category: misc
 type: IR Controller
 standard: au
+chip: CB3S
+unsupported: true
 ---
+
+## Warning! Since 2022-03-19 ships with an incompatible Tuya CB3S. If the box says "HUBIR01HA Series 2" its likley its the incompatible chip.
+
+It might be possible to replace the incompatible CB3S chip with a [ESP-12 S/E/F](https://templates.blakadder.com/ESP-12.html). 
+
+## Old hardware instructions
+
 You will need to flash the tasmota-ir.bin firmware to this deivce.


### PR DESCRIPTION
Bought stock from Bunnings today, device is now shipping with an unsupported Tuya chip CB3S

The box and device has listed "Series 2" and this is probably the indicator that its using the Tuya chip.