### PR TITLE
Update mirabella_genio_I002899

### DIFF
--- a/_templates/mirabella_genio_I002899
+++ b/_templates/mirabella_genio_I002899
@@ -3,7 +3,7 @@ date_added: 2022-02-05
 title: Mirabella Genio Dual USB
 model: I002899
 image: /assets/images/mirabella_genio_I002899.jpg
-template9: '{"NAME":"Mirabella Genio Wi-Fi Power Plug with Dual USB Port","GPIO":[0,0,0,32,0,0,0,0,0,320,0,224,0,0],"FLAG":0,"BASE":18}' 
+template9: '{"NAME":"Mirabella Genio Wi-Fi Power Plug with Dual USB Port","GPIO":[0,0,0,32,0,0,0,0,0,320,224,0,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.woolworths.com.au/shop/productdetails/80169/mirabella-genio-wifi-power-plug-with-dual-2-usb-port
 link2: 
 mlink: https://www.mirabellagenio.com.au/product-range/mirabella-genio-wi-fi-power-plug-with-two-usb-ports/


### PR DESCRIPTION
The relay GPIO for this device is 14 - not 15 that is currently documented. After programming with Tasmota I used the template that was on the site and the relay did not work. After following the tracks on the PCB I found that the relay GPIO is 14. In fact the TYWE2S does not even have a GPIO 15 pin.
I have corrected the template.
I have also created a blog post with how to open this device. You may want to link to it from the page? I was not too sure on what sort of content you wanted on these pages. If you want me to add the photos and description to the template page just let me know.
https://homeopen.wordpress.com/2022/04/27/mirabella-genio-power-plug-two-usb/