### PR TITLE
new version of athom addressable led controller

### DIFF
--- a/_templates/athom_LS2812B-TAS
+++ b/_templates/athom_LS2812B-TAS
@@ -4,6 +4,7 @@ title: Athom 2812b
 model: LS2812B-TAS
 image: /assets/images/athom_LS2812B-TAS.jpg
 template9: '{"NAME":"LS2812B-TAS","GPIO":[32,0,1376,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":18}' 
+template9_alt: '{"NAME":"LS2812B-TAS-V2","GPIO":[32,1376,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":18}' 
 mlink: https://www.athom.tech/blank-1/2812b-led-strip-controller
 link: https://www.aliexpress.com/item/1005002099128276.html
 link2: https://www.mylocalbytes.com/products/athom-wled-strip-controller
@@ -19,7 +20,7 @@ Devices shipped since 5 Jan 2022 have  gpio01 as ledpin instead of gpio02
 
 Template for new version:
 
-`
+```json
 '{"NAME":"LS2812B-TAS-V2","GPIO":[32,1376,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":18}' 
-`
+```
 

--- a/_templates/athom_LS2812B-TAS
+++ b/_templates/athom_LS2812B-TAS
@@ -14,3 +14,12 @@ standard: global
 ---
 
 Supports WLED firmware (uses default binary with ledpin2) and can be bought with WLED preinstalled.
+
+Devices shipped since 5 Jan 2022 have  gpio01 as ledpin instead of gpio02
+
+Template for new version:
+
+`
+'{"NAME":"LS2812B-TAS-V2","GPIO":[32,1376,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":18}' 
+`
+


### PR DESCRIPTION
Athom seeems to have a new version of this controller since 5 Jan 2022 where the pin for ws2812 changed from gpio2 to gpio1