### PR TITLE
Update DS-102_3

### DIFF
--- a/_templates/DS-102_3
+++ b/_templates/DS-102_3
@@ -10,6 +10,11 @@ template: '{"NAME":"DS-102 3 Gang","GPIO":[158,58,0,18,22,19,0,0,17,21,57,23,56]
 link2: https://www.amazon.de/dp/B07WDG36R5/
 link3: https://www.banggood.com/Geekcreit-123-Gang-WiFi-Smart-Light-Switch-Push-Button-Smart-LifeTuya-APP-Remote-Control-Works-with-Alexa-Google-Home-for-Voice-Control-p-1536383.html
 ---
+
+## Warning 
+
+As of May 2022 these switches use a WB3S chip (BK7231T) and are no longer compatible.
+
 The three blue LEDs are configured to toggle with the switches.
 The additional red led behind the left button is configured as link indicator.
 

--- a/_templates/DS-102_3
+++ b/_templates/DS-102_3
@@ -9,6 +9,8 @@ image: https://user-images.githubusercontent.com/5904370/56752390-6fc67100-6788-
 template: '{"NAME":"DS-102 3 Gang","GPIO":[158,58,0,18,22,19,0,0,17,21,57,23,56],"FLAG":0,"BASE":18}'
 link2: https://www.amazon.de/dp/B07WDG36R5/
 link3: https://www.banggood.com/Geekcreit-123-Gang-WiFi-Smart-Light-Switch-Push-Button-Smart-LifeTuya-APP-Remote-Control-Works-with-Alexa-Google-Home-for-Voice-Control-p-1536383.html
+unsupported: true
+chip: WB3S 
 ---
 
 ## Warning 


### PR DESCRIPTION
## Warning 

As of May 2022 these switches use a WB3S chip (BK7231T) and are no longer compatible.