### PR TITLE
Update DS-102_2

### DIFF
--- a/_templates/DS-102_2
+++ b/_templates/DS-102_2
@@ -10,6 +10,11 @@ template: '{"NAME":"DS-102 2 Gang","GPIO":[158,57,0,17,22,18,0,0,0,21,56,255,0],
 link2: https://www.amazon.de/dp/B07WDFVF46/
 link3: https://www.banggood.com/Geekcreit-123-Gang-WiFi-Smart-Light-Switch-Push-Button-Smart-LifeTuya-APP-Remote-Control-Works-with-Alexa-Google-Home-for-Voice-Control-p-1536383.html
 ---
+
+## Warning 
+
+As of May 2022 these switches use a WB3S chip (BK7231T) and are no longer compatible.
+
 The two blue LEDs are configured to toggle with the switches.
 The additional red led behind the left button is configured as link indicator.
 

--- a/_templates/DS-102_2
+++ b/_templates/DS-102_2
@@ -9,6 +9,8 @@ image: https://ae01.alicdn.com/kf/HTB18axGNY2pK1RjSZFsq6yNlXXaQ/Tuya-Smart-life-
 template: '{"NAME":"DS-102 2 Gang","GPIO":[158,57,0,17,22,18,0,0,0,21,56,255,0],"FLAG":0,"BASE":18}' 
 link2: https://www.amazon.de/dp/B07WDFVF46/
 link3: https://www.banggood.com/Geekcreit-123-Gang-WiFi-Smart-Light-Switch-Push-Button-Smart-LifeTuya-APP-Remote-Control-Works-with-Alexa-Google-Home-for-Voice-Control-p-1536383.html
+unsupported: true
+chip: WB3S 
 ---
 
 ## Warning 


### PR DESCRIPTION

## Warning 

As of May 2022 these switches use a WB3S chip (BK7231T) and are no longer compatible.