### PR TITLE
Update DS-102_1

### DIFF
--- a/_templates/DS-102_1
+++ b/_templates/DS-102_1
@@ -9,6 +9,8 @@ image: http://EvertDekker.com/wp/wp-content/uploads/2019/04/TgethDs102.jpg
 template: '{"NAME":"DS-102 1 Gang","GPIO":[158,0,0,17,0,0,0,0,0,21,52,0,0],"FLAG":0,"BASE":18}' 
 link2: https://www.amazon.de/dp/B07WFKJ27C/
 link3: https://www.banggood.com/Geekcreit-123-Gang-WiFi-Smart-Light-Switch-Push-Button-Smart-LifeTuya-APP-Remote-Control-Works-with-Alexa-Google-Home-for-Voice-Control-p-1536383.html
+unsupported: true
+chip: WB3S 
 ---
 
 ## Warning 

--- a/_templates/DS-102_1
+++ b/_templates/DS-102_1
@@ -10,6 +10,11 @@ template: '{"NAME":"DS-102 1 Gang","GPIO":[158,0,0,17,0,0,0,0,0,21,52,0,0],"FLAG
 link2: https://www.amazon.de/dp/B07WFKJ27C/
 link3: https://www.banggood.com/Geekcreit-123-Gang-WiFi-Smart-Light-Switch-Push-Button-Smart-LifeTuya-APP-Remote-Control-Works-with-Alexa-Google-Home-for-Voice-Control-p-1536383.html
 ---
+
+## Warning 
+
+As of May 2022 these switches use a WB3S chip (BK7231T) and are no longer compatible.
+
 The blue LED is configured to indicate switch state, the red LED is configured as link indicator.
 Switch the GPIOs to show switch state in red.
 If you prefer the switch state LED to be illuminated when power is turned OFF, i.e. when the room is dark, replace "Led1i" by "Led1".


### PR DESCRIPTION

## Warning 

As of May 2022 these switches use a WB3S chip (BK7231T) and are no longer compatible.