### PR TITLE
Update espressif-ESP32-S3-DevKitM-1

### DIFF
--- a/_templates/espressif-ESP32-S3-DevKitM-1
+++ b/_templates/espressif-ESP32-S3-DevKitM-1
@@ -9,7 +9,7 @@ mlink: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-referenc
 image: /assets/images/espressif_ESP32-S3-DevKitM-1.png
 flash: serial
 chip: s3
-templates3: {"NAME":"ESP32-S3-DevKitM-1","GPIO":[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1376],"FLAG":0,"BASE":1}
+templates3: '{"NAME":"ESP32-S3-DevKitM-1","GPIO":[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1376],"FLAG":0,"BASE":1}'
 link: https://www.amazon.com/dp/B09R4QQVF4
 ---
 


### PR DESCRIPTION
Template string not quoted gets weird format with `=>` on page, and when copying to clipboard