### PR TITLE
Update arlec_SGS01HA

### DIFF
--- a/_templates/arlec_SGS01HA
+++ b/_templates/arlec_SGS01HA
@@ -79,7 +79,7 @@ var sensorHubID     = Data.substr(0,12)
 // Extract the Sensor Data Values
 var CmndData        = payload.TuyaReceived.CmndData;
 var updateID        = CmndData.substr(0,6);     // Each sensor+battery update shares this string
-var sensorNumber    = parseInt(CmndData.substr(6,2));
+var sensorNumber    = parseInt(CmndData.substr(6,2),16);
 var sensorType      = CmndData.substr(8,6);
 var sensorValue     = CmndData.substr(14);
 


### PR DESCRIPTION
This adds support for more than 10 devices. The sensor number comes as a 2 digit hexadecimal number, so when you get to 0A it previously just parsing it to 0, so you would have multiple devices with ID of 0. Bunnings have these cheap on clearance so I have more than 10 devices now.