### PR TITLE
BL20925 series 2 warning

### DIFF
--- a/_templates/brilliant_BL20925
+++ b/_templates/brilliant_BL20925
@@ -1,6 +1,7 @@
 ---
 date_added: 2019-11-13
-title: Brilliant Lighting BL20925
+title: Brilliant Lighting 
+model: BL20925
 category: plug
 type: Plug
 standard: au
@@ -9,4 +10,4 @@ image: https://user-images.githubusercontent.com/5904370/68767389-e93c8880-0620-
 template: '{"NAME":"BL20925","GPIO":[0,0,0,17,133,132,0,0,131,158,21,0,0],"FLAG":0,"BASE":52}' 
 link2: https://www.ebay.com.au/itm/Brilliant-Lighting-Smart-WiFi-Plug-with-Energy-Monitoring-/323950894186
 ---
-Warning! The "SERIES II" version is **not** ESP based!
+## Warning! The **"SERIES II"** version is **not** ESP based and uses WB2S instead.

--- a/_templates/brilliant_BL20925
+++ b/_templates/brilliant_BL20925
@@ -9,5 +9,4 @@ image: https://user-images.githubusercontent.com/5904370/68767389-e93c8880-0620-
 template: '{"NAME":"BL20925","GPIO":[0,0,0,17,133,132,0,0,131,158,21,0,0],"FLAG":0,"BASE":52}' 
 link2: https://www.ebay.com.au/itm/Brilliant-Lighting-Smart-WiFi-Plug-with-Energy-Monitoring-/323950894186
 ---
-
- 
+Warning! The "SERIES II" version is **not** ESP based!


### PR DESCRIPTION
There is now a "Series II" of the BL20925 smart plug, rather than as esp it has a wb2s controller that is not compatible.