### PR TITLE
Update kogan-KASMCDSKTLA

### DIFF
--- a/_templates/kogan-KASMCDSKTLA
+++ b/_templates/kogan-KASMCDSKTLA
@@ -32,6 +32,10 @@ DpId5
 
 '00000063' is the current temp in hex.
 
+DpType2Id5
+
+Returns the current temp in Deg C.
+
 `setoption66 1` to publish all Tuyareceived data to topic.
 
 Home assitant MQTT Temperature sensor


### PR DESCRIPTION
Added Info about DpType2Id5.

This allows direct access to the current temp in DegC.