### PR TITLE
Fixing templates for Sonoff TH Origin devices for ESP32 gpios

### DIFF
--- a/_templates/sonoff_THR316
+++ b/_templates/sonoff_THR316
@@ -3,7 +3,7 @@ date_added: 2022-07-22
 title: Sonoff TH Origin 16A
 model: THR316
 image: /assets/images/sonoff_THR316.jpg
-template9: '{"NAME":"Sonoff THR316","GPIO":[32,0,0,0,0,0,0,0,0,321,0,576,320,0,0,0,0,224,0,0,0,1,0,3840,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}' 
+template32: '{"NAME":"Sonoff THR316","GPIO":[32,0,0,0,0,0,0,0,0,321,0,576,320,0,0,0,0,224,0,0,0,1,0,3840,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}' 
 link: https://itead.cc/product/sonoff-th/ref/3/
 link2: https://www.aliexpress.com/item/1005004473793143.html
 link3: https://mediarath.de/products/sonoff-thr316-th-origin-16a-sensorgesteuerter-wifi-smart-switch-tasmota

--- a/_templates/sonoff_THR320
+++ b/_templates/sonoff_THR320
@@ -3,7 +3,7 @@ date_added: 2022-07-22
 title: Sonoff TH Origin 20A
 model: THR320
 image: /assets/images/sonoff_THR320.jpg
-template9: '{"NAME":"Sonoff THR320","GPIO":[32,0,0,0,0,0,0,0,0,321,0,576,320,0,0,9312,0,0,9313,0,0,1,0,3840,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}' 
+template32: '{"NAME":"Sonoff THR320","GPIO":[32,0,0,0,0,0,0,0,0,321,0,576,320,0,0,9312,0,0,9313,0,0,1,0,3840,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}' 
 link: https://itead.cc/product/sonoff-th/ref/3/
 link2: https://www.aliexpress.com/item/1005004473793143.html
 link3: https://mediarath.de/products/sonoff-thr320-th-origin-20a-sensorgesteuerter-wifi-smart-switch-tasmota


### PR DESCRIPTION
Having template9 instead of template32 led to confusing layout on the templates repository page