### PR TITLE
Add ESPHome Notes to Globe 4in Recessed Light

### DIFF
--- a/_templates/globe_50359
+++ b/_templates/globe_50359
@@ -15,3 +15,61 @@ standard: us
 Module needed is tywe2s 
 
 Also works with WT32C3-01N Module using the following template `{"NAME":"Globe RGBCCT Downlight","GPIO":[0,0,0,416,419,420,418,0,0,0,417,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}`
+
+WT32C3-01N can work with ESPHome as well - basic configuration as follows.
+
+```
+esphome:
+  platformio_options:
+    board_build.flash_mode: dio
+
+esp32:
+  board: esp32-c3-devkitm-1
+  framework:
+    type: esp-idf
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "ESPHome"
+    password: !secret wifi_password_backup
+
+api: {"password": !secret api_password }
+ota: {"password": !secret ota_password }
+
+light:
+  - platform: rgbww
+    name: "${friendly_name}"
+    red: output_pwm1_red
+    green: output_pwm2_green
+    blue: output_pwm3_blue
+    cold_white: output_pwm5_white_cold
+    warm_white: output_pwm4_white_warm
+    cold_white_color_temperature: 5000 K
+    warm_white_color_temperature: 2000 K
+    constant_brightness: true
+    color_interlock: true
+
+output:
+  - platform: ledc
+    pin: GPIO3
+    frequency: 1200Hz
+    id: output_pwm1_red
+  - platform: ledc
+    pin: GPIO10
+    frequency: 1200Hz
+    id: output_pwm2_green
+  - platform: ledc
+    pin: GPIO6
+    frequency: 1200Hz
+    id: output_pwm3_blue
+  - platform: ledc
+    pin: GPIO5
+    frequency: 1200Hz
+    id: output_pwm4_white_warm
+  - platform: ledc
+    pin: GPIO4
+    frequency: 1200Hz
+    id: output_pwm5_white_cold
+```


### PR DESCRIPTION
Added working notes on how to integrate with ESPHome using ESP-IDF framework. Can be used to extrapolate code for any other Arduino or ESP-IDF type integration.