### PR TITLE
TYWE2S / WT32C3-01N Mappings

### DIFF
--- a/_templates/WT32C3-01N
+++ b/_templates/WT32C3-01N
@@ -15,6 +15,8 @@ link: https://www.alibaba.com/product-detail/CE-RoHS-WT32C3-01N-4MB-Flash_160035
 
 {% include flash/c3.md %}
 
+<sub>This module has no GPIO8, pulling GPIO9 low is sufficient to boot in flash mode</sub>
+
 ![Pinout](/assets/device_images/WT32C3-01N_pinout.webp)
 
 ## Running
@@ -23,3 +25,17 @@ For normal operation connect EN to VCC (pull high) to enable the C3 chip. GPIO9 
 ESP32's are power hungry on boot and the USB to serial adapter might not be able to provide enough power for that. Use a stable 3.3v power supply that can supply more than 500 mA.
 
 [Datasheet](/assets/WT32C3-01N_datasheet.pdf)
+
+## GPIO Mappings
+
+|TYWE2S  |WT32C3-01n|
+|---|---|
+|RST |EN  |
+|AD  |GPIO01  |
+|GPIO01  |GPIO21  |
+|GPIO03  |GPIO20  |
+|GPIO04  |GPIO10  |
+|GPIO05  |GPIO03  |
+|GPIO12  |GPIO05  |
+|GPIO13  |GPIO06  |
+|GPIO14  |GPIO04  |


### PR DESCRIPTION
This adds the relevant approximate pin mappings to use when replacing an existing TWYE2S with an WT32C3-01N. Along with a note on flashing requirements for this particular variant of the C3.