### PR TITLE
Fixing to template9 when new component numbers

### DIFF
--- a/_templates/WF-CS01_EU
+++ b/_templates/WF-CS01_EU
@@ -5,7 +5,7 @@ category: cover
 type: Curtain Switch
 standard: eu
 image: https://ae01.alicdn.com/kf/HTB1s85oKAvoK1RjSZFNq6AxMVXaE.jpg?width=788&height=704&hash=1492
-template: '{"NAME":"ShutterSwitch","GPIO":[544,227,289,34,226,33,0,0,32,224,290,225,288,0],"FLAG":0,"BASE":18,"CMND":"Rule1 1"}'
+template9: '{"NAME":"ShutterSwitch","GPIO":[544,227,289,34,226,33,0,0,32,224,290,225,288,0],"FLAG":0,"BASE":18,"CMND":"Rule1 1"}'
 link: https://www.amazon.de/dp/B07PNV9XKQ/
 link2: https://www.aliexpress.com/item/32983943702.html
 chip: TYWE3S

--- a/_templates/blitzwolf_SHP11
+++ b/_templates/blitzwolf_SHP11
@@ -3,7 +3,6 @@ date_added: 2020-11-22
 title: Blitzwolf SHP11 16A
 model: BW-SHP11
 image: /assets/device_images/blitzwolf_SHP11.webp
-template: '{"NAME":"BlitzWolf-SHP11","GPIO":[320,0,0,2624,0,2720,0,0,0,32,2656,224,0,0],"FLAG":0,"BASE":18}' 
 template9: '{"NAME":"BlitzWolf-SHP11","GPIO":[320,0,0,2624,0,2720,0,0,0,32,2656,224,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.banggood.com/BlitzWolf-BW-SHP11-16A-3520W-UK-Plug-Smart-Switch-APP-Remote-Controller-Timer-Work-with-Amazon-Alexa-Google-Assistant-p-1675285.html?rmmds=myorder&cur_warehouse=UK
 link2: 

--- a/_templates/geekaire_AF1S
+++ b/_templates/geekaire_AF1S
@@ -7,7 +7,7 @@ type: Fan
 standard: us
 flash: tuya-convert
 image: /assets/device_images/geekaire_AF1S.webp
-template: '{"NAME":"Geek Aire Fan","GPIO":[0,2272,0,2304,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":54,"CMND":"TuyaMCU 12,4 | TuyaMCU 13,5"}'
+template9: '{"NAME":"Geek Aire Fan","GPIO":[0,2272,0,2304,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":54,"CMND":"TuyaMCU 12,4 | TuyaMCU 13,5"}'
 link: https://www.amazon.com/dp/B082WBPWBF
 link2: https://www.menards.com/main/heating-cooling/portable-fans/geek-aire-3d-13-oscillating-wifi-desktop-fan/af1s/p-60892399956.htm
 ---

--- a/_templates/gosund_WO1
+++ b/_templates/gosund_WO1
@@ -2,7 +2,7 @@
 date_added: 2021-06-29
 title: Gosund 
 model: WO1
-template: '{"NAME":"Gosund WO1","GPIO":[320,0,576,0,2656,2720,0,0,2624,321,225,224,0,4704],"FLAG":0,"BASE":18}' 
+template9: '{"NAME":"Gosund WO1","GPIO":[320,0,576,0,2656,2720,0,0,2624,321,225,224,0,4704],"FLAG":0,"BASE":18}' 
 image: /assets/device_images/gosund_WO1.webp
 link: https://www.amazon.com/dp/B09JZDSLNC
 mlink: https://us.gosund.com/collections/all-products/products/smart-wall-outlet-with-energy-monitoring-wo1

--- a/_templates/lightsensor_XFY-CGQ-GZ
+++ b/_templates/lightsensor_XFY-CGQ-GZ
@@ -3,7 +3,7 @@ date_added: 2020-12-29
 title: Tuya
 model: SS-LS01
 image: /assets/device_images/lightsensor_XFY-CGQ-GZ.webp
-template: '{"NAME":"Lightsensor","GPIO":[0,2272,0,2304,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":54}' 
+template9: '{"NAME":"Lightsensor","GPIO":[0,2272,0,2304,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":54}' 
 mlink: https://expo.tuya.com/product/687043#detail
 link: https://www.aliexpress.com/item/4001287340039.html
 link2: https://www.aliexpress.com/item/4001220785227.html

--- a/_templates/lolin_TFT_2_4
+++ b/_templates/lolin_TFT_2_4
@@ -6,7 +6,7 @@ category: diy
 type: Display
 standard: global
 image: /assets/device_images/lolin_TFT_2_4.webp
-template: '{"NAME":"Lolin TFT 2.4 Touch Shield","GPIO":[6784,224,225,226,1,992,1,1,672,704,736,5920,5888,1],"FLAG":0,"BASE":18}' 
+template9: '{"NAME":"Lolin TFT 2.4 Touch Shield","GPIO":[6784,224,225,226,1,992,1,1,672,704,736,5920,5888,1],"FLAG":0,"BASE":18}' 
 template32: '{"NAME":"Lolin TFT 2.4 Touch Shield","GPIO":[224,225,226,1,1,6400,1,1,1,1,1,1,1,7264,736,672,0,1,992,704,0,1,6368,1,0,0,0,0,1,1,1,1,1,0,0,1],"FLAG":0,"BASE":1}'
 mlink: https://www.wemos.cc/en/latest/d1_mini_shield/tft_2_4.html
 link: https://www.aliexpress.com/item/32919729730.html

--- a/_templates/luminea_ZX-2858
+++ b/_templates/luminea_ZX-2858
@@ -3,7 +3,7 @@ date_added: 2020-02-03
 title: Luminea ZX-2858
 model: ZX-2858-675
 image: https://user-images.githubusercontent.com/5904370/73696849-743b9500-46dd-11ea-8b72-5e9a581828ea.png
-template: '{"NAME":"ZX2858-675","GPIO":[32,0,0,0,2688,2656,0,0,2624,320,224,0,0,0],"FLAG":0,"BASE":65}' 
+template9: '{"NAME":"ZX2858-675","GPIO":[32,0,0,0,2688,2656,0,0,2624,320,224,0,0,0],"FLAG":0,"BASE":65}' 
 link: https://www.pearl.de/a-ZX2858-3103.shtml?vid=675
 link2: 
 mlink: https://www.luminea.info/Ultrakompakte-WiFi-Steckdose-Adapter-mit-Energie-ZX-2858-919.shtml

--- a/_templates/mixigoo_10W_E27
+++ b/_templates/mixigoo_10W_E27
@@ -6,7 +6,7 @@ category: bulb
 standard: e27
 link: https://www.amazon.de/gp/product/B07VZXDX6J
 image: https://user-images.githubusercontent.com/5904370/66717700-49e76400-eddc-11e9-87f4-2e3b2667eac0.png
-template: '{"NAME":"Mixigoo Bulb RGBCCT","GPIO":[0,0,0,0,416,419,0,0,417,420,418,0,0,0],"FLAG":0,"BASE":18}' 
+template9: '{"NAME":"Mixigoo Bulb RGBCCT","GPIO":[0,0,0,0,416,419,0,0,417,420,418,0,0,0],"FLAG":0,"BASE":18}' 
 link2: 
 flash: tuya-convert
 ---

--- a/_templates/moes_WK-EU_FR_UK16M
+++ b/_templates/moes_WK-EU_FR_UK16M
@@ -2,7 +2,7 @@
 date_added: 2022-09-04
 title: Moes 16A
 model: WK-EU(FR/UK)16M
-template: '{"NAME":"WK-EU(FR/UK)16M","GPIO":[0,288,0,32,2720,2656,0,0,2624,224,0,0,0,0],"FLAG":0,"BASE":18}'
+template9: '{"NAME":"WK-EU(FR/UK)16M","GPIO":[0,288,0,32,2720,2656,0,0,2624,224,0,0,0,0],"FLAG":0,"BASE":18}'
 image: /assets/device_images/moes_WK-EU_FR_UK16M.webp
 link: https://s.click.aliexpress.com/e/_ABwien
 link2: 

--- a/_templates/smartpoint_SPCNTRL-WM
+++ b/_templates/smartpoint_SPCNTRL-WM
@@ -3,7 +3,7 @@ date_added: 2021-09-02
 title: Smartpoint Smart Remote
 model: SPCNTRL-WM
 image: /assets/device_images/smartpoint_SPCNTRL-WM.webp
-template: '{"NAME":"Smartpoint SPCNTRL-WM","GPIO":[0,0,0,0,288,1088,0,0,0,0,1056,0,0,0],"FLAG":0,"BASE":18}' 
+template9: '{"NAME":"Smartpoint SPCNTRL-WM","GPIO":[0,0,0,0,288,1088,0,0,0,0,1056,0,0,0],"FLAG":0,"BASE":18}' 
 link2: https://www.walmart.com/ip/Smartpoint-Wifi-Smart-Remote-Controller-Compatible-with-Alexa-and-Google-Assistant-Hands-Free-Voice-Control/824016383
 link: https://www.amazon.com/dp/B08NFBJCSQ/
 mlink: https://www.smartpointco.com/product-page/smart-wifi-remote-control

--- a/_templates/sonoff_L1_Lite
+++ b/_templates/sonoff_L1_Lite
@@ -5,7 +5,7 @@ model: 692007577636279
 category: light
 type: LED Strip
 standard: [us,eu]
-template: '{"NAME":"Sonoff L1 Lite","GPIO":[0,3200,0,3232,0,0,0,0,0,320,0,0,0,0],"FLAG":0,"BASE":70}' 
+template9: '{"NAME":"Sonoff L1 Lite","GPIO":[0,3200,0,3232,0,0,0,0,0,320,0,0,0,0],"FLAG":0,"BASE":70}' 
 mlink: https://sonoff.tech/product/wifi-smart-lighting/l1-lite
 link: https://itead.cc/product/sonoff-l1-smart-led-light-strip/
 link2: https://www.domadoo.fr/en/peripheriques/5491-sonoff-ruban-de-led-wifi-l1-lite-5m.html

--- a/_templates/supernight_dual
+++ b/_templates/supernight_dual
@@ -6,7 +6,7 @@ type: Plug
 standard: us
 link: https://www.amazon.com/gp/product/B07K1QSFFJ
 image: https://m.media-amazon.com/images/S/aplus-seller-content-images-us-east-1/ATVPDKIKX0DER/AXEJGN8WLZD9M/6265beec-09b0-48b5-a8a5-373cd58b9c79._CR0,0,300,400_PT0_SX300__.jpg
-template: '{"NAME":"SUPERNIGHT","GPIO":[0,32,0,224,2656,2688,0,0,225,2624,576,0,0,4833],"FLAG":0,"BASE":18}' 
+template9: '{"NAME":"SUPERNIGHT","GPIO":[0,32,0,224,2656,2688,0,0,225,2624,576,0,0,4833],"FLAG":0,"BASE":18}' 
 link2: 
 chip: TYWE2S
 ---

--- a/_templates/technical_pro_FXA16
+++ b/_templates/technical_pro_FXA16
@@ -7,7 +7,7 @@ type: Fan
 standard: us
 flash: tuya-convert
 image: https://images-na.ssl-images-amazon.com/images/I/717PZvfnhWL._AC_SL1500_.jpg
-template: '{"NAME":"FXA16 Fan","GPIO":[0,2272,0,2304,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":54,"CMND":"TuyaMCU 12,8"}'
+template9: '{"NAME":"FXA16 Fan","GPIO":[0,2272,0,2304,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":54,"CMND":"TuyaMCU 12,8"}'
 link: https://www.amazon.com/Technical-Pro-Standing-Oscillating-Compatible/dp/B07RM6XQ4L
 ---
 

--- a/_templates/teopek_Spider_Z
+++ b/_templates/teopek_Spider_Z
@@ -4,7 +4,7 @@ title: Teopek Spider Z RGB
 category: light
 type: LED Strip
 standard: [global]
-template: '{"NAME":"Sonoff L1","GPIO":[0,3200,0,3232,0,0,0,0,0,320,0,0,0,0],"FLAG":0,"BASE":70}' 
+template9: '{"NAME":"Sonoff L1","GPIO":[0,3200,0,3232,0,0,0,0,0,320,0,0,0,0],"FLAG":0,"BASE":70}' 
 image: /assets/device_images/teopek_Spider_Z.webp
 mlink: https://ewelinkcommunity.net/device-lists/lights/teopek-spider-z/
 link: https://www.aliexpress.com/item/32881075060.html


### PR DESCRIPTION
These templates clearly are using new component numbers, but tagged as "template" instead of "template9", causing bad display on html page for the templates