### PR TITLE
Fixing to "template" when old component numbers used

### DIFF
--- a/_templates/FM101
+++ b/_templates/FM101
@@ -3,7 +3,7 @@ date_added: 2021-11-01
 title: Tuya Gas/Water
 model: FM101
 image: /assets/device_images/FM101.webp
-template9: '{"NAME":"Valve FM101","GPIO":[56,0,0,0,21,0,0,0,0,0,17,0,22],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"Valve FM101","GPIO":[56,0,0,0,21,0,0,0,0,0,17,0,22],"FLAG":0,"BASE":18}' 
 link: https://aliexpress.com/item/10000055519067.html
 link2: 
 mlink: 

--- a/_templates/cleverio-51573
+++ b/_templates/cleverio-51573
@@ -3,7 +3,7 @@ date_added: 2021-10-20
 title: Cleverio 400lm 5.5W
 model: 51573
 image: /assets/device_images/cleverio-51573.webp
-template9: '{"NAME":"Cleverio 51573","GPIO":[0,0,0,0,0,0,0,0,181,0,180,0,0],"FLAG":0,"BASE":18,"CMND":"SO37 30"}' 
+template: '{"NAME":"Cleverio 51573","GPIO":[0,0,0,0,0,0,0,0,181,0,180,0,0],"FLAG":0,"BASE":18,"CMND":"SO37 30"}' 
 link: https://www.kjell.com/se/produkter/smarta-hem/smarta-hem-losningar/cleverio-smarta-hem/cleverio-smart-gu10-rgb-2.0-led-lampa-400-lm-p51573
 link2: 
 mlink: 

--- a/_templates/cloudfree_P1EU
+++ b/_templates/cloudfree_P1EU
@@ -3,7 +3,7 @@ date_added: 2022-03-15
 title: CloudFree EU
 model: P1EU
 image: /assets/device_images/cloudfree_P1EU.webp
-template9: '{"NAME":"CloudFree P1EU","GPIO":[0,0,56,0,0,134,0,0,131,17,132,21,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"CloudFree P1EU","GPIO":[0,0,56,0,0,134,0,0,131,17,132,21,0],"FLAG":0,"BASE":18}' 
 link: https://cloudfree.shop/product/cloudfree-eu-smart-plug/ 
 link2: https://eu.cloudfree.shop/product/cloudfree-eu-smart-plug/
 mlink: 

--- a/_templates/cloudfree_SW1
+++ b/_templates/cloudfree_SW1
@@ -3,7 +3,7 @@ date_added: 2022-03-15
 title: CloudFree Light
 model: SW1
 image: /assets/device_images/cloudfree_SW1.webp
-template9: '{"NAME":"CloudFree SW1","GPIO":[17,255,0,255,0,0,0,0,21,56,255,0,0],"FLAG":0,"BASE":1}' 
+template: '{"NAME":"CloudFree SW1","GPIO":[17,255,0,255,0,0,0,0,21,56,255,0,0],"FLAG":0,"BASE":1}' 
 link: https://cloudfree.shop/product/cloudfree-light-switch/
 link2: 
 mlink: 

--- a/_templates/globe_50322
+++ b/_templates/globe_50322
@@ -3,7 +3,7 @@ date_added: 2022-01-28
 title: Globe 3 Way
 model: 50322
 image: /assets/device_images/globe_50322.webp
-template9: '{"NAME":"Globe Dimmer","GPIO":[0,107,0,108,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":54,"CMND":"TuyaMCU 11,1 | TuyaMCU 21,2 | Ledtable 0"}' 
+template: '{"NAME":"Globe Dimmer","GPIO":[0,107,0,108,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":54,"CMND":"TuyaMCU 11,1 | TuyaMCU 21,2 | Ledtable 0"}' 
 link: https://www.amazon.ca/dp/B08TT6ZDRC/
 link2: 
 mlink: 

--- a/_templates/globe_50329
+++ b/_templates/globe_50329
@@ -3,7 +3,7 @@ date_added: 2021-11-24
 title: Globe 15A
 model: 50329
 image: /assets/device_images/globe_50329.webp
-template9: '{"NAME":"Globe 50329","GPIO":[0,0,0,0,56,0,0,0,21,0,17,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"Globe 50329","GPIO":[0,0,0,0,56,0,0,0,21,0,17,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.lowes.ca/product/electrical-outlets/globe-electric-smart-mini-wi-fi-plug-1-grounded-outlet-compact-design-15a-white-3311478
 link2: 
 mlink: 

--- a/_templates/haodeng_plug
+++ b/_templates/haodeng_plug
@@ -3,7 +3,7 @@ date_added: 2022-02-01
 title: HaoDeng 
 model: 
 image: /assets/device_images/haodeng_plug.webp
-template9: '{"NAME":"HaoDeng","GPIO":[0,0,0,0,21,17,0,0,56,53,0,0,0],"FLAG":0,"BASE":61}' 
+template: '{"NAME":"HaoDeng","GPIO":[0,0,0,0,21,17,0,0,56,53,0,0,0],"FLAG":0,"BASE":61}' 
 link: https://www.amazon.de/gp/product/B083GJ2BSQ
 link2: 
 mlink: 

--- a/_templates/herepow_ZHX-ZNOC
+++ b/_templates/herepow_ZHX-ZNOC
@@ -3,7 +3,7 @@ date_added: 2022-07-27
 title: HerePow 
 model: ZHX-ZNOC
 image: /assets/device_images/herepow_ZHX-ZNOC.webp
-template9: '{"NAME":"HerePow ZHX-ZNOC","GPIO":[0,157,0,131,134,132,0,0,21,17,56,0,0],"FLAG":0,"BASE":68}' 
+template: '{"NAME":"HerePow ZHX-ZNOC","GPIO":[0,157,0,131,134,132,0,0,21,17,56,0,0],"FLAG":0,"BASE":68}' 
 link: https://www.aliexpress.com/item/1005001350355840.html
 link2: https://www.amazon.de/dp/B08FJDGVD6
 mlink: https://www.alibaba.com/product-detail/EU-WIFI-TUYA-google-home-assistant_1600113712698.html

--- a/_templates/hevolta_glasense_outlet
+++ b/_templates/hevolta_glasense_outlet
@@ -3,7 +3,7 @@ date_added: 2021-11-04
 title: Hevolta Glasense 
 model: 
 image: /assets/device_images/hevolta_glasense_outlet.webp
-template9: '{"NAME":"Hevolta Socket","GPIO":[0,0,0,0,52,53,0,0,21,17,0,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"Hevolta Socket","GPIO":[0,0,0,0,52,53,0,0,21,17,0,0,0],"FLAG":0,"BASE":18}' 
 link: https://eshop.hevolta.sk/kategoria/vypinace-zasuvky/glasense-zasuvky/
 link2: 
 mlink: https://www.hevolta.eu/hevolta-glasense/

--- a/_templates/krida_4ch
+++ b/_templates/krida_4ch
@@ -3,7 +3,7 @@ date_added: 2022-08-25
 title: KRIDA 4 Channel 10A Electromagnetic
 model: 
 image: /assets/device_images/krida_4ch.webp
-template9: '{"NAME":"4CH Relay","GPIO":[0,0,0,0,0,0,0,0,23,22,24,21,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"4CH Relay","GPIO":[0,0,0,0,0,0,0,0,23,22,24,21,0],"FLAG":0,"BASE":18}' 
 link: https://www.tindie.com/products/bugrovs2012/wifi-tasmota-4-channel-10-amps-relay-module/
 link2: 
 mlink: 

--- a/_templates/lsc_smart_connect_3004154
+++ b/_templates/lsc_smart_connect_3004154
@@ -3,7 +3,7 @@ date_added: 2021-11-24
 title: LSC Smart Mood
 model: 3004154
 image: /assets/device_images/lsc_smart_connect_3004154.webp
-template9: '{"NAME":"LSC Mood Light","GPIO":[0,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"LSC Mood Light","GPIO":[0,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.action.com/nl-nl/p/lsc-smart-connect-sfeerlamp/
 link2: 
 mlink: 

--- a/_templates/nedis_WIFILW13WTE14
+++ b/_templates/nedis_WIFILW13WTE14
@@ -3,7 +3,7 @@ date_added: 2022-01-20
 title: Nedis 4.5W 350lm Candle 
 model: WIFILW13WTE14
 image: /assets/device_images/nedis_WIFILW13WTE14.webp
-template9: '{"NAME":"WIFILW13WTE14","GPIO":[0,0,0,0,0,0,0,0,38,0,37,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"WIFILW13WTE14","GPIO":[0,0,0,0,0,0,0,0,38,0,37,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.alzashop.com/nedis-wi-fi-smart-led-bulb-e14-wifilw13wte14-d6242867.htm
 link2: https://www.idealo.de/preisvergleich/Typ/5412810329823.html
 link3: 

--- a/_templates/nedis_WIFIPS10WT
+++ b/_templates/nedis_WIFIPS10WT
@@ -3,7 +3,7 @@ date_added: 2022-01-18
 title: Nedis 10A
 model: WIFIPS10WT
 image: /assets/device_images/nedis_WIFIPS10WT.webp
-template9: '{"NAME":"Nedis WIFIPS10WT","GPIO":[0,0,0,0,21,0,0,0,17,57,0,52,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"Nedis WIFIPS10WT","GPIO":[0,0,0,0,21,0,0,0,17,57,0,52,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.amazon.de/dp/B07HRTX1H4
 link2: https://www.idealo.de/preisvergleich/Typ/5412810303113.html
 mlink: https://nedis.com/en-us/product/smart-home/energy/power-switches/550690706/smartlife-power-switch-wi-fi-2400-w-terminal-block-app-available-for-android-ios-9-x-4-x-25-cm

--- a/_templates/polux_313898
+++ b/_templates/polux_313898
@@ -3,7 +3,7 @@ date_added: 2021-12-19
 title: Polux RGBCCT 
 model: 313898
 image: /assets/device_images/polux_313898.webp
-template9: '{"NAME":"Polux Wi-Fi SM","GPIO":[17,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":37}' 
+template: '{"NAME":"Polux Wi-Fi SM","GPIO":[17,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":37}' 
 link: https://www.polux.sklep.pl/wi-fi-smart-led-tasma-2m-wwcw-rgb-8w-680lm-tuyasmart-p-1363.html
 link2: 
 mlink: https://www.polux.sklep.pl/wi-fi-smart-led-tasma-2m-wwcw-rgb-8w-680lm-tuyasmart-p-1363.html

--- a/_templates/qm_QM20190033
+++ b/_templates/qm_QM20190033
@@ -3,7 +3,7 @@ date_added: 2022-02-03
 title: QM Smart Cloud 4W 350lm 
 model: QM20190033
 image: /assets/device_images/qm_QM20190033.webp
-template9: '{"NAME":"QMSmart RGBCCT","GPIO":[0,0,0,0,0,0,0,0,181,0,180,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"QMSmart RGBCCT","GPIO":[0,0,0,0,0,0,0,0,181,0,180,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.lazada.com.my/products/i2098973938-s8431493262.html?
 link2: 
 mlink: https://www.qmsmartcloud.com/product/remote-control-smart-led-spotlight-gu10-4w/

--- a/_templates/sonoff_iFan04-H
+++ b/_templates/sonoff_iFan04-H
@@ -6,7 +6,7 @@ category: relay
 type: Fan Controller
 standard: eu
 flash: serial
-template9: '{"NAME":"iFan04-H","GPIO":[17,148,0,149,0,0,29,161,23,56,22,24,0],"FLAG":0,"BASE":71}' 
+template: '{"NAME":"iFan04-H","GPIO":[17,148,0,149,0,0,29,161,23,56,22,24,0],"FLAG":0,"BASE":71}' 
 image: /assets/device_images/sonoff_iFan04-H.webp
 mlink: https://sonoff.tech/product/wifi-diy-smart-switches/ifan03
 link: https://itead.cc/product/sonoff-ifan03-wi-fi-ceiling-fan-and-light-controller/

--- a/_templates/unlocked_automation_MK100
+++ b/_templates/unlocked_automation_MK100
@@ -3,7 +3,7 @@ date_added: 2022-07-04
 title: Unlocked Automation 15A
 model: MK100
 image: /assets/device_images/unlocked_automation_MK100.webp
-template9: '{"NAME":"UA 100","GPIO":[0,0,0,0,56,57,0,0,21,17,0,0,0],"FLAG":15,"BASE":18}' 
+template: '{"NAME":"UA 100","GPIO":[0,0,0,0,56,57,0,0,21,17,0,0,0],"FLAG":15,"BASE":18}' 
 link: https://www.amazon.com/dp/B08N9N4D7P/
 mlink: https://unlockedautomation.com/
 flash: preflashed


### PR DESCRIPTION
These templates are using old component numbers, meaning that tagging as new breaks the html page decoding of the values