### PR TITLE
Update download path to new v12 binary names

### DIFF
--- a/_includes/flash/s2.md
+++ b/_includes/flash/s2.md
@@ -2,6 +2,6 @@
 
 Flash using [Tasmota Web Installer](https://tasmota.github.io/install/) and select Tasmota ESP32-S2 option.
 
-For esptool.py download f.e. [`tasmota32c3.factory.bin`](http://ota.tasmota.com/tasmota32/release/tasmota32c3.factory.bin) and run `esptool.py write_flash 0x0 tasmota32c3.factory.bin`
+For esptool.py download i.e. [`tasmota32s2.factory.bin`](http://ota.tasmota.com/tasmota32/release/tasmota32s2.factory.bin) and run `esptool.py write_flash 0x0 tasmota32s2.factory.bin`
 
 To put ESP32-S2 in flash mode GPIO0 needs to be pulled low.  


### PR DESCRIPTION
There are now s2 specific binaries, point to these rather than legacy c3