### PR TITLE
More template GPIO layout concistency

### DIFF
--- a/_templates/DS-101_2
+++ b/_templates/DS-101_2
@@ -3,7 +3,7 @@ date_added: 2020-10-07
 title: DS-101 2 Gang
 model: DS-101
 image: /assets/device_images/DS-101_2.webp
-template9: '{"NAME":"Smart Life Switch","GPIO":[576,289,0,32,225,33,0,0,0,224,288,0,0],"FLAG":0,"BASE":18}' 
+template9: '{"NAME":"Smart Life Switch","GPIO":[576,289,0,32,225,33,0,0,0,224,288,0,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.aliexpress.com/item/1005001670583298.html
 link2: 
 mlink: 

--- a/_templates/ESP-01S-Relay-v4
+++ b/_templates/ESP-01S-Relay-v4
@@ -8,7 +8,7 @@ standard: global
 flash: serial
 image: https://user-images.githubusercontent.com/5904370/66717093-86639180-edd5-11e9-900b-724da9c89916.png
 template: '{"NAME":"ESP01v4","GPIO":[29,56,0,17,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":18}' 
-template9: '{"NAME":"ESP01v4","GPIO":[256,320,0,32,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":18}' 
+template9: '{"NAME":"ESP01v4","GPIO":[256,320,0,32,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":18}' 
 mlink: https://github.com/IOT-MCU/ESP-01S-Relay-v4.0
 link: https://www.amazon.de/AZDelivery-ESP8266-01S-ESP-01-Adapter-Arduino/dp/B078Q3D5MV/
 link2: https://www.amazon.ca/ESP8266-ESP-01S-Module-ESP01S-Control/dp/B07VQG9J4S

--- a/_templates/be_hitech_16A
+++ b/_templates/be_hitech_16A
@@ -3,8 +3,8 @@ date_added: 2020-11-13
 title: Be HiTech 16A
 model: EU3S
 image: /assets/device_images/be_hitech_16A.webp
-template9: '{"NAME":"Be HiTech","GPIO":[0,0,0,288,0,2720,0,0,2624,32,2656,224,0],"FLAG":0,"BASE":18}'
-template9_alt: '{"NAME":"Be HiTech","GPIO":[0,0,320,0,0,2720,0,0,2624,32,2656,224,0],"FLAG":0,"BASE":18}'
+template9: '{"NAME":"Be HiTech","GPIO":[0,0,0,288,0,2720,0,0,2624,32,2656,224,0,0],"FLAG":0,"BASE":18}'
+template9_alt: '{"NAME":"Be HiTech","GPIO":[0,0,320,0,0,2720,0,0,2624,32,2656,224,0,0],"FLAG":0,"BASE":18}'
 link: https://www.amazon.it/dp/B07VWXTMFB/
 link2: https://www.amazon.it/dp/B07VZ18XB2/
 mlink: 

--- a/_templates/martin-jerry-MJ-S01
+++ b/_templates/martin-jerry-MJ-S01
@@ -8,7 +8,7 @@ standard: us
 link: https://www.amazon.com/dp/B07GSTJ8TV
 image: /assets/device_images/martin-jerry-MJ-S01.webp
 template: '{"NAME":"MJ-S01 Switch","GPIO":[0,0,0,0,56,57,0,0,21,17,0,0,0],"FLAG":0,"BASE":18}'
-template9: '{"NAME":"MJ-S01 Switch","GPIO":[0,0,0,0,320,321,0,0,224,32,0,0,0],"FLAG":0,"BASE":18}'
+template9: '{"NAME":"MJ-S01 Switch","GPIO":[0,0,0,0,320,321,0,0,224,32,0,0,0,0],"FLAG":0,"BASE":18}'
 ---
 
 Martin Jerry also offers a version with [Tasmota preflashed](https://templates.blakadder.com/martin-jerry-US-SS01.html)

--- a/_templates/martin_jerry_MJ-SD01
+++ b/_templates/martin_jerry_MJ-SD01
@@ -4,7 +4,7 @@ title: Martin Jerry SD01
 model: MJ-SD01
 image: /assets/device_images/martin_jerry_MJ-SD01.webp
 template: '{"NAME":"MJ-SD02","GPIO":[19,18,0,59,158,58,0,0,57,37,56,122,29],"FLAG":0,"BASE":73}' 
-template9: '{"NAME":"MJ-SD01 Dimmer","GPIO":[34,33,0,323,576,322,0,0,321,416,320,96,256],"FLAG":0,"BASE":73}' 
+template9: '{"NAME":"MJ-SD01 Dimmer","GPIO":[34,33,0,323,576,322,0,0,321,416,320,96,256,0],"FLAG":0,"BASE":73}' 
 link: https://www.amazon.com/dp/B07FXYSVR1
 link2: 
 mlink: https://www.martinjerry.com/

--- a/_templates/martin_jerry_SD01
+++ b/_templates/martin_jerry_SD01
@@ -2,7 +2,7 @@
 date_added: 2022-07-07
 title: Martin Jerry Single Pole
 model: SD01
-template9: '{"NAME":"SD01 Dimmer","GPIO":[34,33,0,323,576,322,0,0,321,416,320,96,256],"FLAG":0,"BASE":73}' 
+template9: '{"NAME":"SD01 Dimmer","GPIO":[34,33,0,323,576,322,0,0,321,416,320,96,256,0],"FLAG":0,"BASE":73}' 
 image: /assets/device_images/martin_jerry_SD01.webp
 link: https://www.amazon.com/dp/B0B2RNSCV1/
 link2: 

--- a/_templates/nous_A1T
+++ b/_templates/nous_A1T
@@ -4,7 +4,7 @@ title: Nous 16A
 model: A1T
 image: /assets/device_images/nous_A1T.webp
 template: '{"NAME":"NOUS A1T","GPIO":[17,0,0,0,134,132,0,0,131,56,21,0,0],"FLAG":0,"BASE":49}'
-template9: '{"NAME":"NOUS A1T","GPIO":[32,0,0,0,2720,2656,0,0,2624,320,224,0,0],"FLAG":0,"BASE":49}'
+template9: '{"NAME":"NOUS A1T","GPIO":[32,0,0,0,2720,2656,0,0,2624,320,224,0,0,0],"FLAG":0,"BASE":49}'
 link: https://www.amazon.de/gp/product/B0054PSIPA
 link2: https://www.domadoo.fr/fr/peripheriques/6209-nous-lot-de-2x-prise-intelligente-wifi-mesure-de-consommation-16a-avec-firmware-tasmota.html
 link3: https://mediarath.de/search?q=Nous+A1T

--- a/_templates/qs-wifi_D01_dimmer
+++ b/_templates/qs-wifi_D01_dimmer
@@ -9,7 +9,7 @@ link: https://www.aliexpress.com/item/33010332202.html
 link2: https://www.banggood.com/MoesHouse-DIY-Smart-WiFi-Light-LED-Dimmer-Switch-Smart-LifeTuya-APP-Remote-Control-12-Way-Switch-Works-With-Alexa-Echo-Google-Home-p-1509161.html
 image: /assets/device_images/qs-wifi_D01_dimmer.webp
 template: '{"NAME":"WiFi-Dimmer","GPIO":[0,148,0,149,0,0,0,0,0,42,37,0,0],"FLAG":0,"BASE":18}' 
-template9: ' {"NAME":"QS-WiFi-D01-TRIAC","GPIO":[0,3200,0,3232,0,0,0,0,0,352,416,0,0],"FLAG":0,"BASE":18}'
+template9: ' {"NAME":"QS-WiFi-D01-TRIAC","GPIO":[0,3200,0,3232,0,0,0,0,0,352,416,0,0,0],"FLAG":0,"BASE":18}'
 ---
 The **Wi-Fi Smart Dimmer Module 150W** is an in-wall push-button dimmer switch, manufactured by Aihomestyle Co LTD and sold as white-label QS-WiFi-D01-TRIAC and also by various brands e.g., _Moes, MoesHouse MS-105, HomCloud, Malmbergs, TOOGOO, Baakey, ..._
 

--- a/_templates/virage_labs_VB-001
+++ b/_templates/virage_labs_VB-001
@@ -3,7 +3,7 @@ date_added: 2022-01-25
 title: Virage Labs VirageBridge 433MHz
 model: VB-001
 image: /assets/device_images/virage_labs_VB-001.webp
-template9: '{"NAME":"VirageBridge","GPIO":[32,3200,1,3232,1,1,0,0,1,320,1,0,0],"FLAG":0,"BASE":25}' 
+template9: '{"NAME":"VirageBridge","GPIO":[32,3200,1,3232,1,1,0,0,1,320,1,0,0,0],"FLAG":0,"BASE":25}' 
 link: https://www.viragelabs.com/product/viragebridge/
 link2: 
 mlink: https://www.viragelabs.com

--- a/_templates/zemismart_YH002
+++ b/_templates/zemismart_YH002
@@ -4,7 +4,7 @@ title: Zemismart Blinds Controller
 model: YH002
 image: /assets/device_images/zemismart_YH002.webp
 template: '{"NAME":"Zemismart Blin","GPIO":[255,255,255,255,255,255,0,0,255,108,255,107,255],"FLAG":0,"BASE":54}' 
-template9: '{"NAME":"Zemismart Blind","GPIO":[1,1,1,1,1,1,0,0,1,2304,1,2272,1],"FLAG":0,"BASE":54}' 
+template9: '{"NAME":"Zemismart Blind","GPIO":[1,1,1,1,1,1,0,0,1,2304,1,2272,1,0],"FLAG":0,"BASE":54}' 
 link: https://www.aliexpress.com/item/4000782412838.html
 link2: 
 mlink: 


### PR DESCRIPTION
Fixing the template GPIO array to 14 entries when "template9", to match how Tasmota works. While this makes no difference to whether the template works or not, I do see consistency as a plus :smile: 