### PR TITLE
Add alternative template from S26 to S26R2

### DIFF
--- a/_templates/sonoff_S26R2
+++ b/_templates/sonoff_S26R2
@@ -26,6 +26,11 @@ mlink: https://sonoff.tech/product/wifi-smart-plugs/s26
 
 This upgraded version is recognized by the "Max..." text printed on the front (Text differs depending on the type of plug).
 
+Alternative template where the blue LED lights up only in case of connection issues and on button actions:
+```console
+{"NAME":"Sonoff S26","GPIO":[17,255,255,255,0,0,0,0,21,158,0,0,0],"FLAG":0,"BASE":8}
+```
+
 ![Pinout](https://user-images.githubusercontent.com/32602435/140815869-29e0c36a-7cc5-4359-8a18-58edbbc67015.jpg)
 
 S26R2TPF has a Espressif Systems 1MB ESP8285 on a small daughter board with no visible connection. Connections points for serial interface is on the backside of the main board labeled V for 3.3v, TX, RX and GND.


### PR DESCRIPTION
The information about the alternative template was only present in the S26 page but not in the S26R2 page. This PR adds it to S26R2 too. I have tested it and it works also on the S26R2