### PR TITLE
Update kogan-KSH2MLEDSPA

### DIFF
--- a/_templates/kogan-KSH2MLEDSPA
+++ b/_templates/kogan-KSH2MLEDSPA
@@ -3,7 +3,7 @@ date_added: 2020-06-28
 title: Kogan RGB + Cool & Warm White 2m
 model: KSH2MLEDSPA
 image: /assets/device_images/kogan-KSH2MLEDSPA.webp
-template: '{"NAME":"RGB+W+C Strip","GPIO":[0,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"RGB+W+C Strip","GPIO":[17,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.kogan.com/au/buy/kogan-smarterhome-rgb-cool-warm-white-smart-led-light-strip-2m/
 link2: 
 mlink: 


### PR DESCRIPTION
I own this product and use it with ESPHome, and have figured out GPIO0 pin is connected to the physical button on the device (and mapped it to toggle the light like in the original firmware). Using the old template codes, I have added it, hopefully can help someone who wants to know what GPIO the button is. (Also tuya-convert did not work when I initially set up tasmota, but could be my fault)