### PR TITLE
My Geeni plug had different pinouts from the page on tasmota

### DIFF
--- a/_templates/geeni-GN-WW104-199
+++ b/_templates/geeni-GN-WW104-199
@@ -14,16 +14,16 @@ link2: https://www.amazon.com/dp/B07FLXG64J
 link3: https://www.walmart.com/ip/Geeni-Spot-Smart-Plug-1-Pack/668255467
 mlink: https://mygeeni.com/collections/power/products/spot-wi-fi-smart-plug
 ---
-# TYWE2S module, with the following pinout on my geenispot:
-# Pin1 is 3.3V
-# Pin2 is IO5 (also TP), connected to 2.2k R4, then the low side of LED2, which is green.
-#  High side of LED2 connects to high side of LED1, and a 1k resistor, R9 to 3.3V.
-# Pin3 is GND
-# Pin4 is IO4 (also TP), connected to R3 (1K). R3 goes to low side of LED1, which is blue.
-# Pin5 is Rx, unused
-# Pin6 is IO13, connected to C5, then button SW1, which drives low when pressed.
-# Pin7 is Tx, unused
-# Pin8 is ADC A1, unused
-# Pin9 is IO12, connected to R5, R9, drives relay.
-# Pin10 is RST, unused
-# Pin11 is IO14, unused
+TYWE2S module, with the following pinout on my geenispot:
+- Pin1 is 3.3V
+- Pin2 is IO5 (also TP), connected to 2.2k R4, then the low side of LED2, which is green.
+-  High side of LED2 connects to high side of LED1, and a 1k resistor, R9 to 3.3V.
+- Pin3 is GND
+- Pin4 is IO4 (also TP), connected to R3 (1K). R3 goes to low side of LED1, which is blue.
+- Pin5 is Rx, unused
+- Pin6 is IO13, connected to C5, then button SW1, which drives low when pressed.
+- Pin7 is Tx, unused
+- Pin8 is ADC A1, unused
+- Pin9 is IO12, connected to R5, R9, drives relay.
+- Pin10 is RST, unused
+- Pin11 is IO14, unused

--- a/_templates/geeni-GN-WW104-199
+++ b/_templates/geeni-GN-WW104-199
@@ -14,3 +14,16 @@ link2: https://www.amazon.com/dp/B07FLXG64J
 link3: https://www.walmart.com/ip/Geeni-Spot-Smart-Plug-1-Pack/668255467
 mlink: https://mygeeni.com/collections/power/products/spot-wi-fi-smart-plug
 ---
+# TYWE2S module, with the following pinout on my geenispot:
+# Pin1 is 3.3V
+# Pin2 is IO5 (also TP), connected to 2.2k R4, then the low side of LED2, which is green.
+#  High side of LED2 connects to high side of LED1, and a 1k resistor, R9 to 3.3V.
+# Pin3 is GND
+# Pin4 is IO4 (also TP), connected to R3 (1K). R3 goes to low side of LED1, which is blue.
+# Pin5 is Rx, unused
+# Pin6 is IO13, connected to C5, then button SW1, which drives low when pressed.
+# Pin7 is Tx, unused
+# Pin8 is ADC A1, unused
+# Pin9 is IO12, connected to R5, R9, drives relay.
+# Pin10 is RST, unused
+# Pin11 is IO14, unused


### PR DESCRIPTION
I got a pinout here:
https://templates.blakadder.com/geeni-GN-WW104-199.html Which, unfortunately, did not work.
I took my plug apart and checked the pinout, which is as follows: # TYWE2S module, with the following pinout on my geenispot: # Pin1 is 3.3V
# Pin2 is IO5 (also TP), connected to 2.2k R4, then the low side of LED2, which is green. #  High side of LED2 connects to high side of LED1, and a 1k resistor, R9 to 3.3V. # Pin3 is GND
# Pin4 is IO4 (also TP), connected to R3 (1K). R3 goes to low side of LED1, which is blue. # Pin5 is Rx, unused
# Pin6 is IO13, connected to C5, then button SW1, which drives low when pressed. # Pin7 is Tx, unused
# Pin8 is ADC A1, unused
# Pin9 is IO12, connected to R5, R9, drives relay. # Pin10 is RST, unused
# Pin11 is IO14, unused

I don't understand how to edit the template to show up correctly on there, but maybe you can edit to fix it or add an alternate, and others could use it?