### PR TITLE
Update arilux_LC11 with new link on guide

### DIFF
--- a/_templates/arilux_LC11
+++ b/_templates/arilux_LC11
@@ -9,4 +9,4 @@ template: '{"NAME":"Arilux LC11","GPIO":[17,0,59,0,38,37,0,0,41,40,39,147,0],"FL
 link2: http://s.click.aliexpress.com/e/mO1RHvlW
 ---
 ## Serial Flashing
-Complete guide at [Tasmota Docs](https://tasmota.github.io/docs/devices/MagicHome-LED-strip-controller#magichome-with-esp8285)
+Complete guide at [Tasmota Docs](https://tasmota.github.io/docs/devices/MagicHome-with-ESP8285/)


### PR DESCRIPTION
The previous link no longer points to the right location. I have replaced it with the new (canonical) link.