### PR TITLE
Modify the correct indicator light

### DIFF
--- a/_templates/athom_SK01-TAS
+++ b/_templates/athom_SK01-TAS
@@ -3,7 +3,7 @@ date_added: 2022-08-10
 title: Athom 
 model: SK01-TAS
 image: /assets/device_images/athom_SK01-TAS.webp
-template9: '{"NAME":"Athom SK01","GPIO":[0,0,0,3104,0,32,0,0,224,576,0,0,0,0],"FLAG":0,"BASE":18}'
+template9: '{"NAME":"Athom SK01","GPIO":[0,0,0,3104,0,32,0,0,224,320,0,0,0,0],"FLAG":0,"BASE":18}'
 mlink: https://www.athom.tech/blank-1/tasmota-eu-wall-socket
 link: https://www.aliexpress.com/item/1005004568734241.html
 link2: 


### PR DESCRIPTION
Because one indicator light needs to indicate relay status and Wi-Fi status