### PR TITLE
fix: typo in Lerlink URL

### DIFF
--- a/_templates/lerlink_X801A
+++ b/_templates/lerlink_X801A
@@ -8,6 +8,7 @@ link: https://www.aliexpress.com/item/1005004178177965.html
 link2: 
 mlink: https://www.lerlink.com/productinfo/1024777.html
 flash: replace
+chip: WB3S
 category: switch
 type: Switch
 standard: 

--- a/_templates/lerlink_X801A-L
+++ b/_templates/lerlink_X801A-L
@@ -15,7 +15,7 @@ standard:
   - uk
 ---
 
-December 2022: The [Lerlink X801A](/lerlink_X801A.html}) is now being shipped with a WB3S module. It is likely that other Lerlink models come with this module also, but this is unknown.
+December 2022: The [Lerlink X801A](/lerlink_X801A.html) is now being shipped with a WB3S module. It is likely that other Lerlink models come with this module also, but this is unknown.
 
 ![Label](https://imgur.com/ohABEHD)
 

--- a/_templates/lerlink_X802A
+++ b/_templates/lerlink_X802A
@@ -13,4 +13,4 @@ type: Switch
 standard: eu
 ---
 
-December 2022: The [Lerlink X801A](/lerlink_X801A.html}) is now being shipped with a WB3S module. It is likely that other Lerlink models come with this module also, but this is unknown.
+December 2022: The [Lerlink X801A](/lerlink_X801A.html) is now being shipped with a WB3S module. It is likely that other Lerlink models come with this module also, but this is unknown.

--- a/_templates/lerlink_X802A
+++ b/_templates/lerlink_X802A
@@ -10,7 +10,9 @@ mlink: https://www.lerlink.com/productinfo/1017149.html
 flash: tuya-convert
 category: switch
 type: Switch
-standard: eu
+standard: 
+  - eu
+  - uk
 ---
 
 December 2022: The [Lerlink X801A](/lerlink_X801A.html) is now being shipped with a WB3S module. It is likely that other Lerlink models come with this module also, but this is unknown.

--- a/_templates/lerlink_X802A-L
+++ b/_templates/lerlink_X802A-L
@@ -16,4 +16,4 @@ standard:
   - uk
 ---
 
-December 2022: The [Lerlink X801A](/lerlink_X801A.html}) is now being shipped with a WB3S module. It is likely that other Lerlink models come with this module also, but this is unknown.
+December 2022: The [Lerlink X801A](/lerlink_X801A.html) is now being shipped with a WB3S module. It is likely that other Lerlink models come with this module also, but this is unknown.

--- a/_templates/lerlink_X803A
+++ b/_templates/lerlink_X803A
@@ -14,4 +14,4 @@ type: Switch
 standard: eu
 ---
 
-December 2022: The [Lerlink X801A](/lerlink_X801A.html}) is now being shipped with a WB3S module. It is likely that other Lerlink models come with this module also, but this is unknown.
+December 2022: The [Lerlink X801A](/lerlink_X801A.html) is now being shipped with a WB3S module. It is likely that other Lerlink models come with this module also, but this is unknown.

--- a/_templates/lerlink_X803A
+++ b/_templates/lerlink_X803A
@@ -11,7 +11,9 @@ mlink: https://www.lerlink.com/productinfo/1017154.html
 flash: serial
 category: switch
 type: Switch
-standard: eu
+standard: 
+  - eu
+  - uk
 ---
 
 December 2022: The [Lerlink X801A](/lerlink_X801A.html) is now being shipped with a WB3S module. It is likely that other Lerlink models come with this module also, but this is unknown.

--- a/_templates/lerlink_X803A-L
+++ b/_templates/lerlink_X803A-L
@@ -13,4 +13,4 @@ type: Switch
 standard: eu
 ---
 
-December 2022: The [Lerlink X801A](/lerlink_X801A.html}) is now being shipped with a WB3S module. It is likely that other Lerlink models come with this module also, but this is unknown.
+December 2022: The [Lerlink X801A](/lerlink_X801A.html) is now being shipped with a WB3S module. It is likely that other Lerlink models come with this module also, but this is unknown.

--- a/_templates/lerlink_X803A-L
+++ b/_templates/lerlink_X803A-L
@@ -10,7 +10,9 @@ mlink: https://www.lerlink.com/productinfo/1017154.html
 flash: serial
 category: switch
 type: Switch
-standard: eu
+standard: 
+  - eu
+  - uk
 ---
 
 December 2022: The [Lerlink X801A](/lerlink_X801A.html) is now being shipped with a WB3S module. It is likely that other Lerlink models come with this module also, but this is unknown.

--- a/_templates/lerlink_X803K-L
+++ b/_templates/lerlink_X803K-L
@@ -14,4 +14,4 @@ standard: us
 chip: TYWE3S
 ---
 
-December 2022: The [Lerlink X801A](/lerlink_X801A.html}) is now being shipped with a WB3S module. It is likely that other Lerlink models come with this module also, but this is unknown.
+December 2022: The [Lerlink X801A](/lerlink_X801A.html) is now being shipped with a WB3S module. It is likely that other Lerlink models come with this module also, but this is unknown.


### PR DESCRIPTION
Accidentally left a `}` in #1648 