### PR TITLE
Date code info for Bright smart plugs and bulbs

### DIFF
--- a/_templates/bright_741235077565
+++ b/_templates/bright_741235077565
@@ -12,4 +12,10 @@ category: plug
 type: Plug
 standard: us
 ---
-Certified Device FC and Intertek 
+Tuya-convert successfully used on 2022-03-06 to flash unused switches, model #50000 with date code stickers (back of switch) EPT0819, EPT0919, and EPT1019 (August, September, and October 2019).
+
+741235077565 is the plug's UPC when sold by itself. This plug can also be found under the UPC 741235101634 in a multi-pack with two model 34205 bulbs. 
+
+The date code is visible on the underside of the packaging in a small box near the UPC; the "EPT1019" plug's packaging read "10A19".
+
+Certified Device FCC and Intertek.

--- a/_templates/bright_741235077565
+++ b/_templates/bright_741235077565
@@ -12,7 +12,7 @@ category: plug
 type: Plug
 standard: us
 ---
-Tuya-convert successfully used on 2022-03-06 to flash unused switches, model #50000 with date code stickers (back of switch) EPT0819, EPT0919, and EPT1019 (August, September, and October 2019).
+Tuya-Convert successfully used on March 6, 2023 to flash unused switches, model #50000 with date code stickers (back of switch) EPT0819, EPT0919, and EPT1019 (August, September, and October 2019).
 
 741235077565 is the plug's UPC when sold by itself. This plug can also be found under the UPC 741235101634 in a multi-pack with two model 34205 bulbs. 
 

--- a/_templates/bright_741235077572
+++ b/_templates/bright_741235077572
@@ -12,4 +12,8 @@ category: bulb
 type: Dimmable
 standard: e26
 ---
+Tuya-convert successfully used on 2022-03-08 to flash an unused bulb, model #34205 with date code BV0819 silkscreened on the bulb (August 2019).
 
+741235077572 is the product's UPC when sold in a pack of three bulbs. This bulb can also be found under the UPC 741235101634 in a multi-pack with two bulbs and a model 50000 single-outlet smart plug. 
+
+The date code is visible on the underside of the packaging in a small box to the right of the UPC; the "BV0819" bulb's packaging read "08A19".

--- a/_templates/globe_50020
+++ b/_templates/globe_50020
@@ -17,7 +17,9 @@ On board identification :  SK522WR-G2
 
 It seems this generic design can be bought under this model number.
 
-Also marketated as Globe's "Bright" line at The Source.
-Successfully bought and flashed with TuyaConvert on Jan 3, 2021
+Also marketed as Globe's "Bright" line at The Source.
+Successfully bought and flashed with Tuya-Convert on Jan 3, 2021.
+
+Purchased two Bright 741235101628 "Smart Wi-Fi Dual Plug" at The Source and flashed with Tuya-Convert on March 7, 2023. The back casing identified them as model SK522-W, with printed date codes EPT0819 and EPT0919 (August and September 2019). Product's outer packaging also indicates date code "08A19" and "09A19" on bottom near UPC.
 
 New board identification: SK522WR-G4 does not work with tuya-convert (April 14, 2022)


### PR DESCRIPTION
I purchased a few Bright-branded devices from The Source and Princess Auto (clearing out old stock from The Source) and all of them were old enough to flash with tuya-convert. I have written up the date code information I found on the labels and the packaging.