### PR TITLE
Added L8 power meter gpio settings and updated description

### DIFF
--- a/_templates/lanbon_L8-HS
+++ b/_templates/lanbon_L8-HS
@@ -6,7 +6,7 @@ category: switch
 type: Display Switch
 standard: [eu, us]
 image: /assets/device_images/lanbon_L8-HS.webp
-template32: '{"NAME":"Lanbon L8","GPIO":[0,0,0,0,0,992,0,0,224,0,225,0,0,0,1024,896,0,6624,6592,864,0,832,416,226,0,0,0,0,417,418,0,352,0,0,0,4736],"FLAG":0,"BASE":1}' 
+template32: '{"NAME":"Lanbon L8","GPIO":[608,0,0,0,640,992,0,0,224,0,225,0,0,0,1024,736,0,800,768,704,6210,672,416,226,0,0,0,0,417,418,0,2688,0,0,0,0],"FLAG":0,"BASE":1}' 
 mlink: https://lanbon.de/
 link: https://www.banggood.com/110-or-220V-4-in-1-Wifi-LCD-Touch-Screen-Smart-Wall-Light-Switch-Smart-Home-Switch-Support-Homekit-Alexa-Google-Home-p-1900875.html
 link2: https://www.amazon.com/gp/product/B09C58T29H
@@ -21,10 +21,12 @@ Working:
 - Status LEDs
 - Screen
 - Touch
+- Power metering based on pulse counter
+(needs power [calibration](https://tasmota.github.io/docs/Power-Monitoring-Calibration/))
 
 Not working:
-- Power metering based on pulse counter
-- Temperature measurement incorrect
+- Voltage and Current metering due to the HLW8012 CF1 & SEL not connected on mains pcb
+- Temperature measurement incorrect or not available on later pcb versions
 
 ## Solderless Flashing
 [Solderless flashing instructions](https://blakadder.com/lanbon-L8-custom-firmware/).


### PR DESCRIPTION
I just obtained a L8-HS EU and wanted to get power metering working.
To check which gpio it is connected to and which chip is used, I measured all unknown (to me) pins which are exposed through the socket on the back.

"CF": IO35 to HLW8012 CF
"HUMI": SENSOR-VN, not connected on the mains pcb
"BP": via R33, Q8, R32 (and R31 to GND) to IO15, not connected on the mains pcb
Either BP or HUMI is in fact connected to a unpopulated spot "P1" next to the connectors to the logic pcb, by silk size and shape (circle) possibly a capacitor, maybe necessary in the dimmer or other variant. The silk shows that the pcb has many different equipping options.

Voltage and Current metering are not available because the CF1 and SEL pins are not connected anywhere on the mains pcb.

With a power meter plug and a 25W halogen bulb I obtained readings of 27.xx W on the power meter and with PowerSet I received 27 W on the web interface, sometimes jerking to 14 or 54 W for less than a second, but most of the time shows 27 W correctly.