### PR TITLE
Update athom_LB01-15W-E27

### DIFF
--- a/_templates/athom_LB01-15W-E27
+++ b/_templates/athom_LB01-15W-E27
@@ -3,7 +3,7 @@ date_added: 2020-12-15
 title: Athom 15W 1400lm
 model: LB01-15W-E27
 image: /assets/device_images/athom_LB01-15W-E27.webp
-template9: '{"NAME":"LB01-15W-E27-TAS","GPIO":[0,0,0,0,416,419,0,0,417,452,418,0,0,0],"FLAG":0,"BASE":18,"CMND":"SO92 1 | DimmerRange 24 100"}' 
+template9: '{"NAME":"LB01-15W-E27-TAS","GPIO":[0,0,0,0,416,419,0,0,417,452,418,0,0,0],"FLAG":0,"BASE":18,"CMND":"SO92 1;DimmerRange 24 100"}' 
 mlink: https://www.athom.tech/blank-1/15w-color-bulb
 link: https://www.aliexpress.com/item/1005001879808728.html
 link2: 


### PR DESCRIPTION
The previous template broke warm light, the new template was taken from the manufacturer's website and is working properly.