### PR TITLE
More nitpicking of template types

### DIFF
--- a/_templates/m5stack_atoms3_lite
+++ b/_templates/m5stack_atoms3_lite
@@ -3,7 +3,7 @@ date_added: 2023-04-28
 title: M5Stack AtomS3 Lite ESP32
 model: C124
 image: /assets/device_images/m5stack_atoms3_lite.webp
-template32: '{"NAME":"M5 AtomS3 Lite","GPIO":[0,1,1,0,1057,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1376,0,0,1,1,0,32,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}'
+templates3: '{"NAME":"M5 AtomS3 Lite","GPIO":[0,1,1,0,1057,1,1,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,1376,0,0,1,1,0,32,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}'
 link: https://www.aliexpress.com/item/1005005177952629.html
 link2: 
 link3: 

--- a/_templates/m5stack_m5stamp_S3
+++ b/_templates/m5stack_m5stamp_S3
@@ -7,13 +7,13 @@ type: Module
 standard: global
 flash: serial
 image: /assets/device_images/m5stack_m5stamp_S3.webp
-templatec3: '{"NAME":"M5Stamp S3","GPIO":[32,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,1,1,1,1376,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1],"FLAG":0,"BASE":1}' 
+templates3: '{"NAME":"M5Stamp S3","GPIO":[32,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,1,1,1,1376,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1],"FLAG":0,"BASE":1}' 
 mlink: https://shop.m5stack.com/products/m5stamp-esp32s3-module
 link: https://www.aliexpress.com/item/1005005199957262.html
 chip: s3
 build: tasmota32s3-cdc
 ---
-The S3 uses the ESP32-C3's built-in USB Serial for program download.
+The S3 uses the ESP32-S3's built-in USB Serial for program download.
 
 Enter flash mode: Long press on the center button of the M5Stamp S3 when the power is off (G0).
 

--- a/_templates/strong_HELO-PLUG-EU
+++ b/_templates/strong_HELO-PLUG-EU
@@ -3,7 +3,7 @@ date_added: 2023-04-16
 title: Strong Helo EU
 model: HELO-PLUG-EU
 image: /assets/device_images/strong_HELO-PLUG-EU.webp
-template9: '{"NAME":"Strong-Helo-PLUG","GPIO":[0,0,0,17,133,132,0,0,131,56,21,0,0],"FLAG":0,"BASE":65}' 
+template: '{"NAME":"Strong-Helo-PLUG","GPIO":[0,0,0,17,133,132,0,0,131,56,21,0,0],"FLAG":0,"BASE":65}' 
 link: https://www.conrad.com/p/strong-helo-plug-eu-helo-plug-eu-wi-fi-socket-1-piece-indoors-3680-w-2619966
 link2: https://www.alza.cz/EN/strong-helo-plug-eu-3ks-d7677045.htm
 mlink: https://www.strong.tv/en/products/plugs/helo-plug-eu/


### PR DESCRIPTION
Additionally, I noticed that https://templates.blakadder.com/heltec_HTIT-WB32LA_V3 has "templates3", which seems plausible for the V3 board, but the template only has 36 pins (instead of the usual 38 for ESP32-S3), making it look like it could be for the V2 board (which has the classic ESP32 instead of S3). 

Having no strong clue about the right config for the V3 board (like those I2C pins), I did no update, but the templates page https://templates.blakadder.com/heltec_HTIT-WB32LA_V3 has blank in the GPIO/Component table, which is "not so great" :wink: 

Parsing the template as classic ESP32 amounts to this:
```
Gpio.00     IO   32 Button1
Gpio.01     TX 3200 Serial Tx
Gpio.02     IO    1 User
Gpio.03     RX 3232 Serial Rx
Gpio.04     IO  640 I2C SDA1
Gpio.05     IO    1 User
Gpio.09     FL    1 User
Gpio.10     FL    1 User
Gpio.12     IO    1 User
Gpio.13     IO    1 User
Gpio.14     IO    1 User
Gpio.15     IO  608 I2C SCL1
Gpio.16     IO 3840 Output Hi
Gpio.17     IO    1 User
Gpio.18     IO    1 User
Gpio.19     IO    1 User
Gpio.20     IO    0 None
Gpio.21     IO    1 User
Gpio.22     IO    1 User
Gpio.23     IO    1 User
Gpio.24     IO    0 None
Gpio.25     IO  288 Led1
Gpio.26     IO    1 User
Gpio.27     IO    1 User
Gpio.06     FL    0 None
Gpio.07     FL    0 None
Gpio.08     FL    0 None
Gpio.11     FL    0 None
Gpio.32     AO    1 User
Gpio.33     AO    1 User
Gpio.34     IA    1 User
Gpio.35     IA    1 User
Gpio.36     IA    1 User
Gpio.37     IA    1 User
Gpio.38     IA    1 User
Gpio.39     IA    1 User
```