### PR TITLE
Fixing templates with old component numbers to not be "template9"

### DIFF
--- a/_templates/bseed_PA-GEBA-01SWP
+++ b/_templates/bseed_PA-GEBA-01SWP
@@ -3,7 +3,7 @@ date_added: 2023-05-23
 title: BSEED 
 model: PA-GEBA-01SWP
 image: /assets/device_images/bseed_PA-GEBA-01SWP.webp
-template9: '{"NAME":"PA-GEBA-01SWP","GPIO":[0,0,0,0,52,57,0,0,21,17,0,0,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"PA-GEBA-01SWP","GPIO":[0,0,0,0,52,57,0,0,21,17,0,0,0],"FLAG":0,"BASE":18}' 
 link: https://www.amazon.de/dp/B0BR5NNQ53
 link2: 
 mlink: 

--- a/_templates/crest_SHSPM1USB
+++ b/_templates/crest_SHSPM1USB
@@ -3,7 +3,7 @@ date_added: 2023-05-25
 title: Crest Smart Home Single Power Adaptor with 2 USB
 model: SHSPM1USB
 image: /assets/device_images/crest_SHSPM1USB.webp
-template9: '{"NAME":"Medion","GPIO":[0,0,0,17,134,132,0,0,131,56,21,0,0],"FLAG":0,"BASE":52}' 
+template: '{"NAME":"Medion","GPIO":[0,0,0,17,134,132,0,0,131,56,21,0,0],"FLAG":0,"BASE":52}' 
 link: https://www.crest.com.au/collections/smart-home-power/products/smart-wifi-controlled-single-power-adaptor-with-2-usb-ports
 link2: 
 mlink: https://www.crest.com.au/collections/smart-home-power/products/smart-wifi-controlled-single-power-adaptor-with-2-usb-ports

--- a/_templates/hifree_T21
+++ b/_templates/hifree_T21
@@ -3,7 +3,7 @@ date_added: 2023-05-28
 title: HiFree Table Lamp
 model: T21
 image: /assets/device_images/hifree_T21.webp
-template9: '{"NAME":"TuyaMCU","GPIO":[108,1,107,1,1,1,1,1,1,1,1,1,1,1],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"TuyaMCU","GPIO":[108,1,107,1,1,1,1,1,1,1,1,1,1],"FLAG":0,"BASE":18}' 
 link: https://www.amazon.com/dp/B099MV5XMX
 link2: 
 mlink: 

--- a/_templates/steren_SHOME-118_v2
+++ b/_templates/steren_SHOME-118_v2
@@ -3,7 +3,7 @@ date_added: 2023-06-04
 title: Steren Dual Plug and USB Charger Wall Outlet (SHOME-118)
 model: SHOME-118 v2
 image: /assets/device_images/steren_SHOME-118_v2.webp
-template9: '{"NAME":"Steren_SHOME-118","GPIO":[158,0,0,17,56,18,0,0,22,21,57,23,0],"FLAG":0,"BASE":18}' 
+template: '{"NAME":"Steren_SHOME-118","GPIO":[158,0,0,17,56,18,0,0,22,21,57,23,0],"FLAG":0,"BASE":18}' 
 link: https://www.steren.com.mx/doble-contacto-wi-fi-y-cargador-usb-con-placa-para-pared.html
 link2: 
 mlink: https://www.steren.com.mx/doble-contacto-wi-fi-y-cargador-usb-con-placa-para-pared.html


### PR DESCRIPTION
Seems that people like to say "template9" even when still using (like copying) old component numbers