### PR TITLE
Update flash sizes listed for ESP8685-WROOM-06

### DIFF
--- a/_templates/ESP8685-WROOM-06
+++ b/_templates/ESP8685-WROOM-06
@@ -16,8 +16,8 @@ footprint: cbu
 ---
 ESP8685 is the new nomenclature for ESP32-C3 based modules. There are two different versions of this module:
 
-- **ESP8685-WROOM-06-H2** with 4Mb flash
-- **ESP8685-WROOM-06-H4** with 2Mb flash. This version is **not recommended** for Tasmota due to low flash space.
+- **ESP8685-WROOM-06-H4** with 4Mb flash
+- **ESP8685-WROOM-06-H2** with 2Mb flash. This version is **not recommended** for Tasmota due to low flash space.
 
 {% include flash/c3.md %}
 


### PR DESCRIPTION
The flash size of the H2 and H4 was incorrect. The ESP8685-WROOM-06-H2 has 2MB flash and the H4 has 4MB. See the datasheet page 9 here: https://www.espressif.com/sites/default/files/documentation/esp8685_datasheet_en.pdf

![comparison](https://github.com/blakadder/templates/assets/965952/c6adc475-f138-4df3-8fc9-b27773490c80)
