### PR TITLE
Fixed Sonoff TX Ultimate led count

### DIFF
--- a/_templates/sonoff_T5-1C-86
+++ b/_templates/sonoff_T5-1C-86
@@ -3,7 +3,7 @@ date_added: 2023-06-02
 title: Sonoff TX Ultimate 1 Gang
 model: T5-1C-86
 image: /assets/device_images/sonoff_T5-1C-86.webp
-template32: '{"NAME":"TX Ultimate 1","GPIO":[0,0,7808,0,7840,3872,0,0,0,1376,0,7776,0,0,224,3232,0,480,3200,0,0,0,3840,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1,"CMND":"Pixels 27"}' 
+template32: '{"NAME":"TX Ultimate 1","GPIO":[0,0,7808,0,7840,3872,0,0,0,1376,0,7776,0,0,224,3232,0,480,3200,0,0,0,3840,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1,"CMND":"Backlog Pixels 28"}' 
 mlink: https://itead.cc/product/sonoff-tx-ultimate-smart-touch-wall-switch/
 link: https://www.aliexpress.com/item/1005005425204052.html
 link2: https://www.domadoo.fr/en/peripheriques/6739-tx-ultimate-smart-touch-wall-switch-1-gang-sonoff.html
@@ -32,7 +32,7 @@ Driver is just recognising touch events for now and reports them to the RESULT t
 
 Control the haptic feedback motor with [`Buzzer`](https://tasmota.github.io/docs/Commands/#buzzer) command
 
-Set the proper LED count with `Pixels 27`. If you want advanced control over LEDs like custom effect and segmenting you need to program them with [Berry](https://tasmota.github.io/docs/Berry_Addressable-LED/). If you do build new effects please share them on the [driver GitHub](https://github.com/blakadder/tx-ultimate/)
+Set the proper LED count with `Pixels 28` (the template should do this automatically). If you want advanced control over LEDs like custom effect and segmenting you need to program them with [Berry](https://tasmota.github.io/docs/Berry_Addressable-LED/). If you do build new effects please share them on the [driver GitHub](https://github.com/blakadder/tx-ultimate/)
 
 ## I2S Audio Support
 

--- a/_templates/sonoff_T5-2C-86
+++ b/_templates/sonoff_T5-2C-86
@@ -3,7 +3,7 @@ date_added: 2023-06-02
 title: Sonoff TX Ultimate 2 Gang
 model: T5-2C-86
 image: /assets/device_images/sonoff_T5-2C-86.webp
-template32: '{"NAME":"TX Ultimate 1","GPIO":[0,0,7808,0,7840,3872,0,0,0,1376,0,7776,0,225,224,3232,0,480,3200,0,0,0,3840,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1,"CMND":"Pixels 27"}' 
+template32: '{"NAME":"TX Ultimate 2","GPIO":[0,0,7808,0,7840,3872,0,0,0,1376,0,7776,0,225,224,3232,0,480,3200,0,0,0,3840,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1,"CMND":"Backlog Pixels 28"}'
 mlink: https://itead.cc/product/sonoff-tx-ultimate-smart-touch-wall-switch/
 link: https://www.aliexpress.com/item/1005005425204052.html
 link2: https://www.domadoo.fr/en/peripheriques/6740-tx-ultimate-smart-touch-wall-switch-2-gang-sonoff.html

--- a/_templates/sonoff_T5-3C-86
+++ b/_templates/sonoff_T5-3C-86
@@ -3,7 +3,7 @@ date_added: 2023-06-02
 title: Sonoff TX Ultimate 3 Gang
 model: T5-3C-86
 image: /assets/device_images/sonoff_T5-3C-86.webp
-template32: '{"NAME":"TX Ultimate 1","GPIO":[0,0,7808,0,7840,3872,0,0,0,1376,0,7776,0,225,224,3232,0,480,3200,0,0,0,3840,226,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1,"CMND":"Pixels 27"}' 
+template32: '{"NAME":"TX Ultimate 3","GPIO":[0,0,7808,0,7840,3872,0,0,0,1376,0,7776,0,225,224,3232,0,480,3200,0,0,0,3840,226,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1,"CMND":"Backlog Pixels 28"}'
 mlink: https://itead.cc/product/sonoff-tx-ultimate-smart-touch-wall-switch/
 link: https://www.aliexpress.com/item/1005005425204052.html
 link2: https://www.domadoo.fr/en/peripheriques/6741-tx-ultimate-smart-touch-wall-switch-3-gang-sonoff.html


### PR DESCRIPTION
The Sonoff TX Ultimate switches have 4x7=28 leds, not 27 such as mentioned in the documentation and the template: https://templates.blakadder.com/sonoff_T5-1C-86

Oddly enough, it seems that the default Tasmota config of 30 pixels is overriding the template here so it's effectively 30 for me if I don't change anything.
https://github.com/arendst/Tasmota/blob/bfe0857094211a4c0c7084353be076d908d79bf5/tasmota/my_user_config.h#L309

I think the `Pixels` command in the template doesn't work because it's not using the backlog so I've added that and it appears to work for me now :)