### PR TITLE
Update GPIO mapping for SB160207 - B22

### DIFF
--- a/_templates/smitch_SB160207-B22
+++ b/_templates/smitch_SB160207-B22
@@ -3,7 +3,7 @@ date_added: 2020-10-20
 title: Smitch 7W
 model: SB160207 - B22
 image: /assets/device_images/smitch_SB160207-B22.webp
-template: '{"NAME":"Smitch RGB 7W SB-1602","GPIO":[0,0,0,0,37,40,0,0,38,41,39,0,0],"FLAG":0,"BASE":18}'
+template: '{"NAME":"Smitch RGB 7W SB-1602","GPIO":[0,0,0,0,140,40,0,0,38,142,141,0,0],"FLAG":0,"BASE":18}'
 link: https://www.flipkart.com/smitch-wi-fi-rgb-7w-b22-base-smart-bulb/p/itm3fbfde5c50598?pid=LLSFDWHACQYK57XR&lid=LSTLLSFDWHACQYK57XR00SZKI&marketplace=FLIPKART&sattr[]=wattage&st=wattage
 link2: 
 mlink: http://www.mysmitch.com/#blurb-tabs


### PR DESCRIPTION
 * RGB LEDs do not work with the current configuration of pin 4, 13, 14. RGB LEDs are driven with SM16726 chip so map the pins properly. Using driver of SM16716 here since the logics are identical and works perfectly too.