### PR TITLE
Update lilygo_T-Relay-S3

### DIFF
--- a/_templates/lilygo_T-Relay-S3
+++ b/_templates/lilygo_T-Relay-S3
@@ -3,7 +3,7 @@ date_added: 2023-08-14
 title: Lilygo T-Relay S3
 model: T-RELAYS3
 image: /assets/device_images/lilygo_T-Relay-S3.webp
-templates3: '{"NAME":"LilyGo T-RelayS3","GPIO":[8352,1,1,1,1,8288,8320,8384,1,1,1,1,1,1,1,1,640,608,1,1,1,1,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1],"FLAG":0,"BASE":1}' 
+templates3: '{"NAME":"LilyGo T-RelayS3","GPIO":[8352,1,1,1,1,8288,8320,8384,1,1,1,1,1,1,1,1,640,608,1,1,1,1,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1,1],"FLAG":0,"BASE":1}' 
 link: https://www.lilygo.cc/products/t-relay-s3
 link2: https://www.aliexpress.com/item/1005005561802558.html
 link3: https://www.banggood.com/LILYGO-T-Relay-S3-ESP32-S3-6-Way-6CH-Relay-Development-Board-ESP32-S3-WROOM-1U-Wireless-Module-WiFi-Bluetooth-Expandable-LCD-Display-p-1995323.html


### PR DESCRIPTION
Invalid template corrected to 38 pins (as other S3 devices) instead of 37. After this, the assigned pins 74x595/I2C match the info on the LilyGo site.