### PR TITLE
Update zemismart_YH002 template

### DIFF
--- a/_templates/zemismart_YH002
+++ b/_templates/zemismart_YH002
@@ -4,12 +4,13 @@ title: Zemismart Blinds Controller
 model: YH002
 image: /assets/device_images/zemismart_YH002.webp
 template: '{"NAME":"Zemismart Blin","GPIO":[255,255,255,255,255,255,0,0,255,108,255,107,255],"FLAG":0,"BASE":54}' 
-template9: '{"NAME":"Zemismart Blind","GPIO":[1,1,1,1,1,1,0,0,1,2304,1,2272,1,0],"FLAG":0,"BASE":54}' 
-template9: '{"NAME":"Zemismart Blind","GPIO":[0,2272,0,2304,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":54,"CMND":"TuyaMCU 11,7|TuyaMCU 21,2"}'
+template9_alt: '{"NAME":"Zemismart Blind TYWE3S","GPIO":[1,1,1,1,1,1,0,0,1,2304,1,2272,1,0],"FLAG":0,"BASE":54}' 
+template9: '{"NAME":"Zemismart Blind WBR3","GPIO":[0,2272,0,2304,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":54,"CMND":"TuyaMCU 11,7|TuyaMCU 21,2"}'
 link: https://www.aliexpress.com/item/4000782412838.html
 link2: 
 mlink: 
-flash: tuya-convert
+flash: replace
+chip: WBR3
 category: cover
 type: Motor
 standard: global

--- a/_templates/zemismart_YH002
+++ b/_templates/zemismart_YH002
@@ -5,6 +5,7 @@ model: YH002
 image: /assets/device_images/zemismart_YH002.webp
 template: '{"NAME":"Zemismart Blin","GPIO":[255,255,255,255,255,255,0,0,255,108,255,107,255],"FLAG":0,"BASE":54}' 
 template9: '{"NAME":"Zemismart Blind","GPIO":[1,1,1,1,1,1,0,0,1,2304,1,2272,1,0],"FLAG":0,"BASE":54}' 
+template9: '{"NAME":"Zemismart Blind","GPIO":[0,2272,0,2304,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":54,"CMND":"TuyaMCU 11,7|TuyaMCU 21,2"}'
 link: https://www.aliexpress.com/item/4000782412838.html
 link2: 
 mlink: 
@@ -13,6 +14,8 @@ category: cover
 type: Motor
 standard: global
 ---
+Newer units come with a WBR3 module, in which case, it can be replaced with a ESP-12F module. In this case, use the template above that sets the TuyaTx/TuyaRx functions on GPIO1/GPIO3 respectively (it also incorporates the two TuyaMCU mappings described below).
+
 `TuyaMCU 11,7` to move the relay to an uncontrollable dpId. WebUI toggle will have no effect.
 
 `TuyaMCU 21,2` maps the position command to dimmer, will not update position state on its own without the following rule.


### PR DESCRIPTION
New models come with WBR3 (instead of TWYE1S) module, which needs to be replaced with ESP-12F to work. Add a template for such frankensteined units.