### PR TITLE
add sunton 7 inch

### DIFF
--- a/_templates/sunton_ESP32-8048S050
+++ b/_templates/sunton_ESP32-8048S050
@@ -3,7 +3,7 @@ date_added: 2022-02-16
 title: Sunton 5" IPS 800*480
 model: ESP32-8048S050 
 image: /assets/device_images/sunton_ESP32-8048S050.webp
-templates3: '{"NAME":"SUNTON","GPIO":[1,1,1,1,1,1,1,1,1,1,6720,704,736,672,1,1,1,1,1,640,608,1,0,0,0,0,0,6210,1,1,1,1,1,1,1,1,1,1],"FLAG":0,"BASE":1,"CMND":"DisplayDimmer 70"}' 
+templates3: '{"NAME":"SUNTON5","GPIO":[1,1,1,1,1,1,1,1,1,1,6720,704,736,672,1,1,1,1,1,640,608,1,0,0,0,0,0,6210,1,1,1,1,1,1,1,1,1,1],"FLAG":0,"BASE":1,"CMND":"DisplayDimmer 70"}' 
 link: https://www.aliexpress.com/item/1005004952694042.html
 link2: https://www.aliexpress.com/i/1005005653322585.html
 mlink: 

--- a/_templates/sunton_ESP32-8048S070
+++ b/_templates/sunton_ESP32-8048S070
@@ -5,7 +5,7 @@ model: ESP32-8048S070
 image: /assets/device_images/sunton_ESP32-8048S050.webp
 templates3: '{"NAME":"SUNTON7","GPIO":[1,1,1,1,1,1,1,1,1,1,6720,704,736,672,1,1,1,1,1,640,608,1,0,0,0,0,0,6210,1,1,1,1,1,1,1,1,1,1],"FLAG":0,"BASE":1,"CMND":"DisplayDimmer 70"}' 
 link: https://aliexpress.com/item/1005004952726089.html
-link2:
+link2: https://de.aliexpress.com/item/1005005099968475.html
 mlink: 
 flash: serial
 category: diy

--- a/_templates/sunton_ESP32-8048S070
+++ b/_templates/sunton_ESP32-8048S070
@@ -1,0 +1,16 @@
+---
+date_added: 2023-12-29
+title: Sunton 7" TFT 800*480
+model: ESP32-8048S070 
+image: /assets/device_images/sunton_ESP32-8048S050.webp
+templates3: '{"NAME":"SUNTON7","GPIO":[1,1,1,1,1,1,1,1,1,1,6720,704,736,672,1,1,1,1,1,640,608,1,0,0,0,0,0,6210,1,1,1,1,1,1,1,1,1,1],"FLAG":0,"BASE":1,"CMND":"DisplayDimmer 70"}' 
+link: https://aliexpress.com/item/1005004952726089.html
+link2:
+mlink: 
+flash: serial
+category: diy
+type: Display
+standard: global
+autoconf: true
+chip: s3
+---

--- a/_templates/sunton_ESP32-8048S070
+++ b/_templates/sunton_ESP32-8048S070
@@ -5,7 +5,7 @@ model: ESP32-8048S070
 image: /assets/device_images/sunton_ESP32-8048S050.webp
 templates3: '{"NAME":"SUNTON7","GPIO":[1,1,1,1,1,1,1,1,1,1,6720,704,736,672,1,1,1,1,1,640,608,1,0,0,0,0,0,6210,1,1,1,1,1,1,1,1,1,1],"FLAG":0,"BASE":1,"CMND":"DisplayDimmer 70"}' 
 link: https://aliexpress.com/item/1005004952726089.html
-link2: https://de.aliexpress.com/item/1005005099968475.html
+link2: https://www.aliexpress.com/item/1005005099968475.html
 mlink: 
 flash: serial
 category: diy


### PR DESCRIPTION
add sunton 7 inch display
change template name to make difference clear in sunton 5 inch

relates to this issue in Tasmota: https://github.com/arendst/Tasmota/issues/20341#issuecomment-1872259273

Tasmota autoconf-PR to be consistent with this PR: https://github.com/tasmota/autoconf/pull/39


The boards are identical except for the display driver IC, which changes the pinout.
So the Tasmota template is the same, but the display.ini differs and hence does the autoconf package. 