### PR TITLE
Fix addon interface image link

### DIFF
--- a/_templates/shelly_1
+++ b/_templates/shelly_1
@@ -32,7 +32,7 @@ An ESP8266 with 2MB flash single relay device 42mm "round" in size.
 ## Serial Connection
 Shelly1 comes with a partially exposed programming/debug header which can be used to flash Tasmota on the device. A serial-to-USB adapter is needed as well as a reliable 3.3V source with at least 350 mA drive capability. The following diagram shows the device pinout.
 
-<img src="https://kb.shelly.cloud/__attachments/57049089/Gen1-addon-interface.png" height="250" />
+<img src="https://kb.shelly.cloud/__attachments/237502485/Gen1-addon-interface.png" height="250" />
 
 ## Flash mode
 To be able to flash the Tasmota firmware you need to get into flash mode. Therefore connect a wire from GPIO0 to ground. For further information have a look at [Hardware Preparation](https://tasmota.github.io/docs/Getting-Started/#hardware-preparation#bringing-the-module-in-flash-mode).


### PR DESCRIPTION
Looks like the Shelly Knowledge base has updated their docs, and the old image that was being used was replaced with a different url.