### PR TITLE
Add pinout pic obtained from Athom support

### DIFF
--- a/_templates/athom_RS01
+++ b/_templates/athom_RS01
@@ -29,6 +29,10 @@ I took the component apart to flash the device
 
 ![Top of the ESP8285H16](/assets/device_images/RS01_module_top.webp)
 
+According to Athom support, _"Our module is the same as_ https://tasmota.github.io/docs/Pinouts/#tywe2s 
+
+![tywe2s pinout](https://tasmota.github.io/docs/_media/pinouts/TYWE2S_pinout.jpg)
+
 You have to ground this POGO pin pad to ground in order to intialize serial flash (white wire)
 
 ![Flashing pinout](/assets/device_images/RS01_module_flash.webp)


### PR DESCRIPTION
Hi. I've been trying to modify this relay, wasn't sure about the GPIO numbering and decided to ask support. Despite the Lunar new year celebrations, they've promptly responded. I've added their pic to the description.

```
On Wed, Feb 14, 2024 at 04:17 ATHOM Support <support@athom.tech> wrote:
Hi

Our module is the same as https://tasmota.github.io/docs/Pinouts/#tywe2s

Support Team


Athom Technology Co.,Ltd
Add: Rm C2402 Tianhui Bldg, [YouSong Rd Shenzhen, China](https://www.google.com/maps/search/YouSong+Rd+Shenzhen,+China?entry=gmail&source=g) 
Tel: +86 755 23746321 Mobile: +86 13902469242
Web: www.athom.tech 
Online Store: [athom.aliexpress.com](http://athom.aliexpress.com/)
```