### PR TITLE
Create ESP32-S3-DevKitC-1-N16R8V

### DIFF
--- a/_templates/ESP32-S3-DevKitC-1-N16R8V
+++ b/_templates/ESP32-S3-DevKitC-1-N16R8V
@@ -1,0 +1,21 @@
+---
+date_added: 2024-03-27
+title: Espressif ESP32-S3-DevKitC-1-N16R8V
+model: ESP32-S3-DevKitC-1-N16R8V
+image: /assets/device_images/espressif_ESP32-S3-DevKitC-1.webp
+templates3: '{"NAME":"ESP32-S3-DevKitC-1-N16R8V","GPIO":[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0,1376,1,1,1,1,1,1,1,1,1,1],"FLAG":0,"BASE":1}'
+category: diy
+type: Development Board
+standard: global
+mlink: https://docs.espressif.com/projects/esp-idf/en/latest/esp32s3/hw-reference/esp32s3/user-guide-devkitc-1.html
+link: https://www2.mouser.com/ProductDetail/Espressif-Systems/ESP32-S3-DevKitC-1-N32R8V?qs=Li%252BoUPsLEnvTvWIWLPCZ4g%3D%3D
+flash: serial
+chip: s3
+autoconf: true
+---
+Flash: 16 MB Octal SPI (OT)
+PSRAM: 8 MB Octal SPI (OT)
+
+For boards with Octal SPI flash/PSRAM memory embedded, the pins GPIO35, GPIO36 and GPIO37 are used for the internal communication between ESP32-S3 and SPI flash/PSRAM memory, thus not available for external use.
+
+Used `tasmota32s3-opi_opi.factory.bin` and Tasmota Web Installer to flash the device with built in USB-C serial adapter. [Download](https://github.com/Jason2866/Tasmota-specials/blob/firmware/firmware/tasmota32/other/tasmota32s3-opi_opi.factory.bin)


### PR DESCRIPTION
Add support for Espressif ESP32-S3-DevKitC-1-N16R8V board:
- Module Integrated: ESP32-S3-WROOM-2-N16R8V
- Flash: 16 MB Octal SPI (OT)
- PSRAM: 8 MB Octal SPI (OT)

