### PR TITLE
Update topgreener_TGWF500D

### DIFF
--- a/_templates/topgreener_TGWF500D
+++ b/_templates/topgreener_TGWF500D
@@ -3,7 +3,7 @@ date_added: 2020-07-19
 title: TopGreener TGWF500D
 model: ZZH-WF500D
 image: /assets/device_images/topgreener_TGWF500D.webp
-template: '{"NAME":"TopGreener-Dimmer","GPIO":[0,0,0,0,0,0,0,0,0,108,0,107,0],"FLAG":0,"BASE":54,"CMND":"TuyaMCU 21,3 | DimmerRange 10,25"}' 
+template: '{"NAME":"TopGreener-Dimmer","GPIO":[0,0,0,0,0,0,0,0,0,108,0,107,0],"FLAG":0,"BASE":54,"CMND":"TuyaMCU 21,3|DimmerRange 10,25"}' 
 link: https://www.amazon.com/dp/B07BSX9SDF/
 link2: https://www.walmart.com/ip/TOPGREENER-Smart-in-Wall-Wi-Fi-Dimmer-Switch-Single-Pole-Neutral-Wire-Required-White/549626252
 mlink: 


### PR DESCRIPTION
In Tasmota 13.4 the template never successfully runs DimmerRange. I think it send " DimmerRange" which fails with command not found. Removing the spaces around the pipe fixes this problem.