### PR TITLE
shelly PM mini: add missing end quote to CMND of template

### DIFF
--- a/_templates/shelly_plus_1pm_mini
+++ b/_templates/shelly_plus_1pm_mini
@@ -3,7 +3,7 @@ date_added: 2023-10-19
 title: Shelly Plus 1PM Mini
 model: SNSW-001P8EU
 image: /assets/device_images/shelly_plus_1pm_mini.webp
-templatec3: '{"NAME":"Shelly Plus1PMMini","GPIO":[576,32,0,4736,0,224,3200,8161,0,0,192,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1,"CMND":"AdcParam1 2,5600,4700,3350}' 
+templatec3: '{"NAME":"Shelly Plus1PMMini","GPIO":[576,32,0,4736,0,224,3200,8161,0,0,192,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1,"CMND":"AdcParam1 2,5600,4700,3350"}'
 link: https://www.domadoo.fr/en/lighting/6807-shelly-micromodule-commutateur-wi-fi-avec-mesure-d-energie-shelly-p-3800235265666.html
 link2: https://www.amazon.de/dp/B0CH8KB7YB
 link3: https://www.reichelt.com/de/en/shelly-plus-1-pm-mini-1-channel-wlan-bluetooth-max-8-a-mea-shelly-plus-1pmm-p358361.html

--- a/_templates/shelly_plus_pm_mini
+++ b/_templates/shelly_plus_pm_mini
@@ -3,7 +3,7 @@ date_added: 2023-10-19
 title: Shelly Plus PM Mini
 model: SNPM-001PCEU16
 image: /assets/device_images/shelly_plus_pm_mini.webp
-templatec3: '{"NAME":"Shelly PlusPMMini","GPIO":[576,32,0,4736,0,0,3200,8161,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1,"CMND":"AdcParam1 2,5600,4700,3350}' 
+templatec3: '{"NAME":"Shelly PlusPMMini","GPIO":[576,32,0,4736,0,0,3200,8161,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1,"CMND":"AdcParam1 2,5600,4700,3350"}'
 link: https://www.domadoo.fr/en/energy-monitoring-consumption-measurement/6806-shelly-micromodule-compteur-d-energie-16a-shelly-plus-pm-mini-3800235265673.html
 link2: https://www.amazon.de/dp/B0CH18PSPZ
 link3: https://www.conrad.com/en/p/shelly-plus-pm-mini-test-module-wi-fi-bluetooth-2917165.html


### PR DESCRIPTION
removes a trailing whitespace in the changed lines.