### PR TITLE
Update ESP32_Relay_X2 relay pins

### DIFF
--- a/_templates/ESP32_Relay_X2
+++ b/_templates/ESP32_Relay_X2
@@ -3,7 +3,7 @@ date_added: 2022-12-18
 title: LC Technology DC5-60V 2 Channel
 model: ESP32_Relay_X2
 image: /assets/device_images/ESP32_Relay_X2.webp
-template32: '{"NAME":"ESP32_Relay_X2","GPIO":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,544,0,225,224,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}'
+template32: '{"NAME":"ESP32_Relay_X2","GPIO":[0,0,0,0,0,0,0,0,0,0,0,0,224,225,0,0,0,0,0,544,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}'
 link: https://www.aliexpress.com/item/1005004403054853.html
 mlink: 
 flash: serial

--- a/_templates/ESP32_Relay_X2
+++ b/_templates/ESP32_Relay_X2
@@ -4,6 +4,7 @@ title: LC Technology DC5-60V 2 Channel
 model: ESP32_Relay_X2
 image: /assets/device_images/ESP32_Relay_X2.webp
 template32: '{"NAME":"ESP32_Relay_X2","GPIO":[0,0,0,0,0,0,0,0,0,0,0,0,224,225,0,0,0,0,0,544,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}'
+template32_alt: '{"NAME":"ESP32_Relay_X2","GPIO":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,544,0,225,224,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}'
 link: https://www.aliexpress.com/item/1005004403054853.html
 mlink: 
 flash: serial


### PR DESCRIPTION
Using this template did not work on my board, searching around found the relay pins are GPIO16 and GPIO17 (see https://devices.esphome.io/devices/ESP32-Relay-X2 for esphome config)