### PR TITLE
Update seeedstudio_mmwave_sensor_kit

### DIFF
--- a/_templates/seeedstudio_mmwave_sensor_kit
+++ b/_templates/seeedstudio_mmwave_sensor_kit
@@ -13,6 +13,6 @@ link2:
 flash: serial
 ---
 
-[Berry driver](https://github.com/blakadder/berry-drivers/R24D) for Seeedstudio mmWave Lite thats included in the kit.
+[Berry driver](https://github.com/blakadder/berry-drivers/tree/main/R24D) for Seeedstudio mmWave Lite thats included in the kit.
 
 [Documentation](https://wiki.seeedstudio.com/mmwave_human_detection_kit/)


### PR DESCRIPTION
Fixing dead link.

But the driver code fails, missing variables a1, a2. See: https://discord.com/channels/479389167382691863/790185752855052288/1312085988771762198