### PR TITLE
Update nous_D3T Temperature fix

### DIFF
--- a/_templates/nous_D3T
+++ b/_templates/nous_D3T
@@ -15,7 +15,8 @@ standard: eu
 ---
 ---
 ## Fix Temperature Offset
-Use this Command in Console to fix the Temperature-Offset
-```
+Use this command in console to fix the temperature offset
+
+```console
 AdcParam 2,40000,100000,3950,0
 ```

--- a/_templates/nous_D3T
+++ b/_templates/nous_D3T
@@ -13,3 +13,9 @@ category: relay
 type: DIN Relay
 standard: eu
 ---
+---
+## Fix Temperature Offset
+Use this Command in Console to fix the Temperature-Offset
+```
+AdcParam 2,40000,100000,3950,0
+```

--- a/_templates/nous_D3T
+++ b/_templates/nous_D3T
@@ -13,8 +13,9 @@ category: relay
 type: DIN Relay
 standard: eu
 ---
----
+
 ## Fix Temperature Offset
+
 Use this command in console to fix the temperature offset
 
 ```console


### PR DESCRIPTION
without the fix the shown temperature is wrong,
the parameters were read from the factory settings and are lost when updating from 14.0.1 to 14.4.1, so they must be reset afterwards