### PR TITLE
More recent tuya convert flash info

### DIFF
--- a/_templates/gosund_SW9
+++ b/_templates/gosund_SW9
@@ -14,4 +14,6 @@ standard: eu
 ---
 Tuya convert worked with devices ordered in 2021-11.
 
+Ordered in 2025-02, tuya convert worked with models manufactured in 2022-09, but did not work with models manufactured in 2024-01.
+
 Serial pins on board, standard flashing.


### PR DESCRIPTION
Listed a breaking manufacturing date when tuya convert stopped working (due to patched firmware).