### PR TITLE
Update shelly_plus_0-10v_dimmer

### DIFF
--- a/_templates/shelly_plus_0-10v_dimmer
+++ b/_templates/shelly_plus_0-10v_dimmer
@@ -3,7 +3,7 @@ date_added: 2023-10-29
 title: Shelly Plus 0-10V Dimmer
 model: SNDM-00100WW
 image: /assets/device_images/shelly_plus_0-10v_dimmer.webp
-template32: '{"NAME":"Shelly Plus 0-10V Dimmer","GPIO":[288,0,0,0,192,0,0,0,0,0,0,0,0,0,193,1,0,0,0,0,0,32,416,0,0,0,0,0,4736,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}'
+template32: '{"NAME":"Shelly Plus 0-10V Dimmer","GPIO":[288,0,0,0,192,0,0,0,0,0,0,0,0,0,193,1,0,0,0,0,0,32,448,0,0,0,0,0,4736,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}'
 mlink: https://www.shelly.com/en-se/products/product-overview/shelly-plus-0-10-v-dimmer
 flash: mgos32
 category: dimmer


### PR DESCRIPTION
People are reporting that 100% dimming became off, and better behavior inverting the PWM pin. https://github.com/arendst/Tasmota/discussions/22982
Looks like the template needed a bit of improvement here.