### PR TITLE
Update wyze_WLPPO1 - Add information about Roku Outdoor Smart Plug SE (identical hardware)

### DIFF
--- a/_templates/wyze_WLPPO1
+++ b/_templates/wyze_WLPPO1
@@ -1,6 +1,6 @@
 ---
 date_added: 2021-02-03
-title: Wyze 
+title: Wyze / Roku
 model: WLPPO1
 image: /assets/device_images/wyze_WLPPO1.webp
 template32: '{"NAME":"Wyze Plug Outdoor","GPIO":[0,0,0,0,0,576,0,0,0,0,0,224,321,7713,7712,320,0,0,0,0,0,2624,2656,2720,0,0,0,0,225,0,4704,0,0,0,0,0],"FLAG":0,"BASE":1}'
@@ -12,6 +12,10 @@ category: plug
 type: Outdoor Plug
 standard: us
 ---
+
+There are two versions of this smart plug with the same FCC ID and model number, the "Wyze Plug Outdoor" and "Roku Outdoor Smart Plug SE". They are completely identical in hardware, but have different firmware. 
+
+The Roku Outdoor Smart Plug SE's firmware has Secure Boot v2 and Flash Encryption enabled, and the UART bootloader disabled. **It is not possible to flash the Roku version of this hardware with custom firmware.**
 
 ## Flashing
 There are test points large enough for soldering, BOOT (GPIO0), RXD, TXD, and GND are right next to each other.  3V3 is some distance away (right next to the power cord).


### PR DESCRIPTION
The Roku Outdoor Smart Plug SE has identical hardware and FCC ID to the Wyze Plug Outdoor, but it has all of the security features buttoned up properly, unlike Wyze's firmware - the module uses the ESP32-v3 which can have the UART bootloader disabled, and Secure Boot v2 and flash encryption are enabled. I was unable to get any sort of response using esptool on the Roku model whereas the normal methods of UART flashing worked immediately on the Wyze model. I'm pretty sure it's not possible to flash this with custom firmware with current knowledge.

I assume the same could very well be true of the corresponding indoor 1-plug Roku smartplug, which is also a rebranding of Wyze WLPP1 hardware, but I do not have this hardware to check.