### PR TITLE
Fixing a few broken image links

### DIFF
--- a/_templates/kuled-ks602s
+++ b/_templates/kuled-ks602s
@@ -14,10 +14,10 @@ Easily flashable with Tuya Convert
 ## Serial flash
 Some revisions of the switch have the header marked GND, RXD, TXD, 3V3. Some revisions do not.  It has been reported that some boxes have mixed revisions.  If you are ever in doubt, double check with a meter to determine your pins.  Flashing process and hardware revision without the labels can be seen on the following [video link](https://www.youtube.com/watch?v=4nX90vhAniQ).
 
-![](https://github.com/lvgeek/KS-602S/blob/master/images/IMG_0282.jpg)
-![](https://github.com/lvgeek/KS-602S/blob/master/images/IMG_0285.jpg)
-![](https://github.com/lvgeek/KS-602S/blob/master/images/IMG_0286.jpg)
-![](https://github.com/lvgeek/KS-602S/blob/master/images/IMG_0287.jpg)
+![](https://github.com/lvgeek/KS-602S/blob/master/images/IMG_0282.jpg?raw=true)
+![](https://github.com/lvgeek/KS-602S/blob/master/images/IMG_0285.jpg?raw=true)
+![](https://github.com/lvgeek/KS-602S/blob/master/images/IMG_0286.jpg?raw=true)
+![](https://github.com/lvgeek/KS-602S/blob/master/images/IMG_0287.jpg?raw=true)
 
 RXD is connected to Transmit on your programmer
 TXD is connected to Receive on your programmer
@@ -25,8 +25,8 @@ Ground and 3.3vdc to power unit during flash.
 
 You do not need to solder a header to flash the board, an empty 4 pin header connected to 4 dupont jumper wires held into the empty header location works fine with a little pressure to ensure connectivity.
 
-![](https://github.com/lvgeek/KS-602S/blob/master/images/IMG_0289.jpg)
+![](https://github.com/lvgeek/KS-602S/blob/master/images/IMG_0289.jpg?raw=true)
 
 Hold the button(GPIO0) and plug in programmer.
 
-![](https://github.com/lvgeek/KS-602S/blob/master/images/IMG_0298.jpg)
+![](https://github.com/lvgeek/KS-602S/blob/master/images/IMG_0298.jpg?raw=true)

--- a/_templates/robus_RVACCT2-WIFI
+++ b/_templates/robus_RVACCT2-WIFI
@@ -15,7 +15,7 @@ standard: global
 ![Main][main]
 ![Close][close]
 
-[main]: https://github.com/m-hume/RVACCT2-WIFI/blob/main/IMG_5240.jpg
-[close]: https://github.com/m-hume/RVACCT2-WIFI/blob/main/IMG_5241.jpg
+[main]: https://github.com/m-hume/RVACCT2-WIFI/blob/main/IMG_5240.jpg?raw=true
+[close]: https://github.com/m-hume/RVACCT2-WIFI/blob/main/IMG_5241.jpg?raw=true
 
 as per https://tasmota.github.io/docs/TuyaMCU-Devices/#dm_wf_mdv4-leading-edge-dimmer ""In order to flash via serial, the RST pin needs to be grounded upon boot"" and obviously IO0 also"


### PR DESCRIPTION
Github image links fails without raw=true in the URL