### PR TITLE
Fixing placement of added warning

### DIFF
--- a/_templates/neo_coolcam_NAS-AB02W
+++ b/_templates/neo_coolcam_NAS-AB02W
@@ -1,7 +1,4 @@
 ---
-In 2025 the below no longer appears to reflect current devices purchased on Aliexpress. On opening one up (version without sensors, just the siren), the board says v4 with a date of 2022.11.29, and 
-there is no IO0 pin exposed, nor RXD0 / TXD0 pads. 
-
 date_added: 2021-09-06
 title: NEO Coolcam Temperature and Humidity 3in1 Alarm
 model: NAS-AB02W
@@ -19,6 +16,10 @@ standard: global
 author: blak
 ---
 This is a Tuya siren with temperature and humidity sensor. Runs on USB and two CR123A batteries as backup (not supplied with the device). 
+
+## Warning
+In 2025 the below no longer appears to reflect current devices purchased on Aliexpress. On opening one up (version without sensors, just the siren), the board says v4 with a date of 2022.11.29, and 
+there is no IO0 pin exposed, nor RXD0 / TXD0 pads. 
 
 ## Hardware Versions
 


### PR DESCRIPTION
Moved added warning out of the metadata block, as this caused both the warning and gpio/template info to not be displayed.