### PR TITLE
Update ESP32_Relay_X8, quoting template32

### DIFF
--- a/_templates/ESP32_Relay_X8
+++ b/_templates/ESP32_Relay_X8
@@ -3,7 +3,7 @@ date_added: 2022-11-03
 title: LC Technology 5V/7-30V 8 Channel 
 model: ESP32_Relay_X8
 image: /assets/device_images/ESP32_Relay_X8.webp
-template32: {"NAME":"ESP32_Relay_X8","GPIO":[1,1,1,1,1,1,1,1,230,231,229,1,1,1,1,1,1,1,1,288,1,226,227,228,1,1,1,1,224,225,1,1,1,1,1,1],"FLAG":0,"BASE":1}
+template32: '{"NAME":"ESP32_Relay_X8","GPIO":[1,1,1,1,1,1,1,1,230,231,229,1,1,1,1,1,1,1,1,288,1,226,227,228,1,1,1,1,224,225,1,1,1,1,1,1],"FLAG":0,"BASE":1}'
 link: https://www.aliexpress.com/item/1005004391118766.html
 link2: https://www.ebay.com/itm/334469754255
 link3: https://www.amazon.com/Development-Programmable-Wireless-Channel-ESP32-WROOM-32E/dp/B0DK6QKNBM/ref=cm_cr_arp_d_product_top?ie=UTF8&th=1


### PR DESCRIPTION
The template parsing fails without the string being wrapped in single quotes. Hence broken formatting on https://templates.blakadder.com/ESP32_Relay_X8 Looks like it was loaded as a map instead of as a string.