### PR TITLE
Fix monthly template list

### DIFF
--- a/list.json
+++ b/list.json
@@ -8,6 +8,6 @@ layout: null
 ## {{group.name}}
 {% assign grouptitlesorted = group.items | sort_natural: 'title' %}     
 {% for template in grouptitlesorted %}
-{{ template.title | normalize_whitespace }}            {% if template.template32 != nil %}{{ template.template32 }}{% elsif template.template9 != nil %}{{ template.template9 }}{% else %}{{ template.template }}{% endif %}
+{{ template.title | normalize_whitespace }}            {% if template.templatec6 != nil %}{{ template.templatec6 }}{% elsif template.templates3 != nil %}{{ template.templates3 }}{% elsif template.templates2 != nil %}{{ template.templates2 }}{% elsif template.templatec3 != nil %}{{ template.templatec3 }}{% elsif template.templatec2 != nil %}{{ template.templatec2 }}{% elsif template.template32 != nil %}{{ template.template32 }}{% elsif template.template9 != nil %}{{ template.template9 }}{% else %}{{ template.template }}{% endif %}
 {% endfor %}
 {% endfor %}

--- a/templates.json
+++ b/templates.json
@@ -15,7 +15,7 @@ layout: null
         {% if template.type != nil %}"type":     "{{ template.type }}",{% endif %}
         {% if template.category != nil %}"category": "{{ template.category }}",{% endif %}
         {% if template.standard != nil %}"standard": [{% assign standard_list = template.standard %}{% for item_standard in standard_list %}"{{ item_standard | upcase }}"{% unless forloop.last %},{% endunless %}{% endfor %}],{% endif %}
-        {% if template.template32 != nil %}"template": {{ template.template32 }}{% elsif template.template9 != nil %}"template": {{ template.template9 }}{% else %}"template": {{ template.template }}{% endif %},
+        {% if template.templatec6 != nil %}"template": {{ template.templatec6 }}{% elsif template.templates3 != nil %}"template": {{ template.templates3 }}{% elsif template.templates2 != nil %}"template": {{ template.templates2 }}{% elsif template.templatec3 != nil %}"template": {{ template.templatec3 }}{% elsif template.templatec2 != nil %}"template": {{ template.templatec2 }}{% elsif template.template32 != nil %}"template": {{ template.template32 }}{% elsif template.template9 != nil %}"template": {{ template.template9 }}{% else %}"template": {{ template.template }}{% endif %},
         {% if template.image != nil %}"image":    {{ template.image | jsonify }},{% endif %}
         "product":  {% if template.link == nil %}null{% else %}{{ template.link | jsonify }}{% endif %}
         }{% unless forloop.last %},{% endunless %}


### PR DESCRIPTION
126 devices were previously falling through to the ESP8266 template field (wrong output): 75 templatec3, 25 templates3, 11 templates2, 10 templatec2, and 5 templatec6 devices that had no template32 or template9.

Both list.json and templates.json now check all six ESP32 processor-specific fields (templatec6 → templates3 → templates2 → templatec3 → templatec2 → template32) before falling back  to template9 and template.

Fixes #1991 by @arendst 