### PR TITLE
Add 7 IoTextra modules for IoTsmart ESP32-S3

### DIFF
--- a/_templates/makethingshappy_iotextra_analog
+++ b/_templates/makethingshappy_iotextra_analog
@@ -1,0 +1,11 @@
+---
+date_added: 2026-06-26
+title: IoTextra Analog
+category: other
+type: Analog Expansion Module
+standard: global
+link: https://makethingshappy.io/products/iotextra-analog
+mlink: https://makethingshappy.io/g040401311
+image: /assets/device_images/iotextra_analog_v3.11.webp
+template: '{"NAME":"IoTextra Analog","GPIO":[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,608,640,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}'
+---

--- a/_templates/makethingshappy_iotextra_analog3
+++ b/_templates/makethingshappy_iotextra_analog3
@@ -1,0 +1,11 @@
+---
+date_added: 2026-06-26
+title: IoTextra Analog3
+category: other
+type: Analog Expansion Module
+standard: global
+link: https://makethingshappy.io/products/iotextra-analog3
+mlink: https://makethingshappy.io/g040403311
+image: /assets/device_images/iotextra_analog3_v3.11.webp
+template: '{"NAME":"IoTextra Analog3","GPIO":[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,608,640,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}'
+---

--- a/_templates/makethingshappy_iotextra_combo
+++ b/_templates/makethingshappy_iotextra_combo
@@ -1,0 +1,11 @@
+---
+date_added: 2026-06-26
+title: IoTextra Combo
+category: other
+type: Combo Expansion Module
+standard: global
+link: https://makethingshappy.io/products/iotextra-combo
+mlink: https://makethingshappy.io/g040601304
+image: /assets/device_images/iotextra_combo_v3.03_and_v.3.04.webp
+template: '{"NAME":"IoTextra Combo","GPIO":[1,1,1,1,256,257,258,259,1,1,1,1,1,1,1,608,640,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}'
+---

--- a/_templates/makethingshappy_iotextra_input
+++ b/_templates/makethingshappy_iotextra_input
@@ -1,0 +1,11 @@
+---
+date_added: 2026-06-26
+title: IoTextra Input
+category: other
+type: Digital Expansion Module
+standard: global
+link: https://makethingshappy.io/products/iotextra-input
+mlink: https://makethingshappy.io/g040101302
+image: /assets/device_images/iotextra_input_v3.02.webp
+template: '{"NAME":"IoTextra Input","GPIO":[1,1,1,1,160,161,162,163,164,165,166,167,1,1,1,608,640,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}'
+---

--- a/_templates/makethingshappy_iotextra_mosfet2
+++ b/_templates/makethingshappy_iotextra_mosfet2
@@ -1,0 +1,11 @@
+---
+date_added: 2026-06-26
+title: IoTextra MOSFET2
+category: other
+type: Digital Expansion Module
+standard: global
+link: https://makethingshappy.io/products/iotextra-mosfet2
+mlink: https://makethingshappy.io/g040206302
+image: /assets/device_images/iotextra_mosfet2_v3.02.webp
+template: '{"NAME":"IoTextra MOSFET2","GPIO":[1,1,1,1,256,257,258,259,260,261,262,263,1,1,1,608,640,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}'
+---

--- a/_templates/makethingshappy_iotextra_octal
+++ b/_templates/makethingshappy_iotextra_octal
@@ -1,0 +1,11 @@
+---
+date_added: 2026-06-26
+title: IoTextra Octal
+category: other
+type: Digital Expansion Module
+standard: global
+link: https://makethingshappy.io/products/iotextra-octal
+mlink: https://makethingshappy.io/g040302304
+image: /assets/device_images/iotextra_octal_v3.04.webp
+template: '{"NAME":"IoTextra Octal","GPIO":[1,1,1,1,256,257,258,259,160,161,162,163,1,1,1,608,640,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}'
+---

--- a/_templates/makethingshappy_iotextra_ssr_small
+++ b/_templates/makethingshappy_iotextra_ssr_small
@@ -1,0 +1,11 @@
+---
+date_added: 2026-06-26
+title: IoTextra SSR Small
+category: other
+type: Digital Expansion Module
+standard: global
+link: https://makethingshappy.io/products/iotextra-ssr-small
+mlink: https://makethingshappy.io/g040203302
+image: /assets/device_images/iotextra_ssr_small_v3.02.webp
+template: '{"NAME":"IoTextra SSR Small","GPIO":[1,1,1,1,256,257,258,259,260,261,262,263,1,1,1,608,640,1,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"FLAG":0,"BASE":1}'
+---


### PR DESCRIPTION
Adding Tasmota templates for 7 IoTextra expansion modules compatible with IoTsmart ESP32-S3:
- IoTextra Input
- IoTextra SSR Small
- IoTextra MOSFET2
- IoTextra Octal
- IoTextra Analog
- IoTextra Analog3
- IoTextra Combo