### PR TITLE
Updating ESP8684-WROOM templates to match ESP32-C2 pin count

### DIFF
--- a/_templates/ESP8684-WROOM-03
+++ b/_templates/ESP8684-WROOM-03
@@ -6,7 +6,7 @@ category: diy
 type: Module
 standard: global
 image: /assets/device_images/ESP8684-WROOM-03.webp
-templatec2: '{"NAME":"ESP8684-WROOM-03","GPIO":[0,1,0,1,1,1,1,1,0,1,0,0,0,0,0,0,0,0,0,0,1,1],"FLAG":0,"BASE":1}'
+templatec2: '{"NAME":"ESP8684-WROOM-03","ARCH":"ESP32C2","GPIO":[0,1,0,1,1,1,1,1,0,1,1,0,0,0,0,0,0,0,0,1,1],"FLAG":0,"BASE":1}'
 mlink: 
 link: https://www.aliexpress.com/item/1005004815394120.html
 link2: https://www.amazon.in/dp/B0B6VXZ3QB

--- a/_templates/ESP8684-WROOM-05
+++ b/_templates/ESP8684-WROOM-05
@@ -6,7 +6,7 @@ category: diy
 type: Module
 standard: global
 image: /assets/device_images/ESP8684-WROOM-05.webp
-templatec2: '{"NAME":"ESP8684-WROOM-05","GPIO":[0,0,0,1,1,1,1,1,0,1,0,0,0,0,0,0,0,0,0,0,1,1],"FLAG":0,"BASE":1}'
+templatec2: '{"NAME":"ESP8684-WROOM-05","ARCH":"ESP32C2","GPIO":[0,0,0,1,1,1,1,1,0,1,0,0,0,0,0,0,0,0,0,1,1],"FLAG":0,"BASE":1}'
 mlink: https://www.espressif.com/en/support/documents/technical-documents?keys=&field_type_tid%5B%5D=1139
 link: https://www.aliexpress.com/item/1005004827667639.html
 link2: https://www.aliexpress.com/item/1005004437164146.html


### PR DESCRIPTION
Templates had 22 pins matching ESP32-C3 instead of the 21 pins ESP32-C2 has.