### PR TITLE
Update dingtian_DT-R002

### DIFF
--- a/_templates/dingtian_DT-R002
+++ b/_templates/dingtian_DT-R002
@@ -3,7 +3,7 @@ date_added: 2025-01-27
 title: Dingtian 2 Channel
 model: DT-R002
 image: assets/device_images/dingtian_DT-R002.png
-template32: '{"NAME":"Dingtian DT-R002","GPIO":[5536,9408,225,9440,0,0,0,0,0,9952,0,0,224,0,5600,0,0,0,0,5568,0,0,0,0,0,0,0,0,576,0,0,0,160,0,0,161],"FLAG":0,"BASE":1}' 
+template32: '{"NAME":"Dingtian DT-R002","GPIO":[5536,9408,225,9440,0,0,0,0,0,0,0,0,224,0,5600,0,0,0,0,5568,0,0,0,0,0,0,0,0,576,9952,0,0,160,0,0,161],"FLAG":0,"BASE":1}'
 link: https://nl.aliexpress.com/item/1005007020455160.html
 mlink: https://www.dingtian-tech.com/en_us/relay2.html
 flash: serial


### PR DESCRIPTION
Tx Enable pin was set on gpio13 in the template but it has to be gpio33 according to documentation. I found this issue while using a dingtian 002 with modbus which didn't work with the original template.